### PR TITLE
Add question validation config and new question types

### DIFF
--- a/src/components/form/question/FormQuestion.vue
+++ b/src/components/form/question/FormQuestion.vue
@@ -1,7 +1,11 @@
 <script lang="ts" setup>
 import { computed, nextTick, onMounted, ref, shallowRef, watch } from "vue";
 import type { Component } from "vue";
-import type { Question, QuestionChoice, QuestionType } from "@/types/pocketbase";
+import type {
+  Question,
+  QuestionChoice,
+  QuestionType,
+} from "@/types/pocketbase";
 
 import XEditor from "@/components/inputs/Editor.vue";
 import XDropdown from "@/components/inputs/Dropdown.vue";

--- a/src/components/form/question/FormQuestion.vue
+++ b/src/components/form/question/FormQuestion.vue
@@ -1,13 +1,15 @@
 <script lang="ts" setup>
-import { nextTick, onMounted, ref, shallowRef, watch } from "vue";
+import { computed, nextTick, onMounted, ref, shallowRef, watch } from "vue";
 import type { Component } from "vue";
-import type { Question, QuestionChoice } from "@/types/pocketbase";
+import type { Question, QuestionChoice, QuestionType } from "@/types/pocketbase";
 
 import XEditor from "@/components/inputs/Editor.vue";
 import XDropdown from "@/components/inputs/Dropdown.vue";
 import XToggle from "@/components/inputs/Toggle.vue";
 import Answer from "@/components/form/question/Answer.vue";
 import type { ChoiceItem } from "@/components/form/question/Answer.vue";
+import QuestionValidation from "@/components/form/question/QuestionValidation.vue";
+import { supportsValidation } from "@/utils/validation";
 
 import IconCheckbox from "@/components/icons/question/Checkbox.vue";
 import IconShortText from "@/components/icons/question/ShortText.vue";
@@ -15,6 +17,10 @@ import IconLongText from "@/components/icons/question/LongText.vue";
 import IconSelect from "@/components/icons/question/Select.vue";
 import IconDropdown from "@/components/icons/question/Dropdown.vue";
 import IconLinearScale from "@/components/icons/question/LinearScale.vue";
+import IconNumber from "@/components/icons/question/Number.vue";
+import IconEmail from "@/components/icons/question/Email.vue";
+import IconDate from "@/components/icons/question/Date.vue";
+import IconRating from "@/components/icons/question/Rating.vue";
 
 import IconArrowDown from "@/components/icons/controls/ArrowDown.vue";
 import IconCopy from "@/components/icons/controls/Copy.vue";
@@ -41,7 +47,7 @@ const emits = defineEmits<{
 }>();
 
 const questionTypeOptions = shallowRef<
-  { name: string; value: Question["type"]; icon: Component }[]
+  { name: string; value: QuestionType; icon: Component }[]
 >([
   { name: "Short Text", value: "short_text", icon: IconShortText },
   { name: "Paragraph", value: "long_text", icon: IconLongText },
@@ -49,10 +55,25 @@ const questionTypeOptions = shallowRef<
   { name: "Checkboxes", value: "multiple_choice", icon: IconCheckbox },
   { name: "Dropdown", value: "dropdown", icon: IconDropdown },
   { name: "Linear Scale", value: "linear_scale", icon: IconLinearScale },
+  { name: "Number", value: "number", icon: IconNumber },
+  { name: "Email", value: "email", icon: IconEmail },
+  { name: "Date", value: "date", icon: IconDate },
+  { name: "Rating", value: "rating", icon: IconRating },
 ]);
 
 const currentQuestionOption = shallowRef(questionTypeOptions.value[0]);
 const questionConfig = ref({ ...props.question });
+const showValidation = ref(false);
+
+// Validation config is persisted inside the question's `settings` JSON. Proxy it
+// so the panel can v-model it directly while lazily creating `settings`.
+const validationModel = computed({
+  get: () => questionConfig.value.settings?.validation ?? null,
+  set: (value) => {
+    if (!questionConfig.value.settings) questionConfig.value.settings = {};
+    questionConfig.value.settings.validation = value;
+  },
+});
 
 function choicesToItems(choices: QuestionChoice[] | undefined): ChoiceItem[] {
   return (choices ?? []).map((c) => ({ id: c.id, label: c.label }));
@@ -183,6 +204,33 @@ onMounted(() => {
               : 'Long text'
           "
         />
+        <input
+          v-else-if="currentQuestionOption.value === 'number'"
+          type="number"
+          class="w-full bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-600 py-2 px-4 placeholder:text-neutral-400 outline-none rounded-md"
+          readonly
+          placeholder="Number"
+        />
+        <input
+          v-else-if="currentQuestionOption.value === 'email'"
+          type="text"
+          class="w-full bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-600 py-2 px-4 placeholder:text-neutral-400 outline-none rounded-md"
+          readonly
+          placeholder="email@example.com"
+        />
+        <input
+          v-else-if="currentQuestionOption.value === 'date'"
+          type="text"
+          class="w-full bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-600 py-2 px-4 placeholder:text-neutral-400 outline-none rounded-md"
+          readonly
+          placeholder="dd/mm/yyyy"
+        />
+        <div
+          v-else-if="currentQuestionOption.value === 'rating'"
+          class="flex items-center gap-x-1 text-neutral-300 dark:text-neutral-500"
+        >
+          <IconRating v-for="n in 5" :key="n" class="w-7 h-7" />
+        </div>
         <Answer
           v-else-if="
             currentQuestionOption.value === 'multiple_choice' ||
@@ -193,6 +241,12 @@ onMounted(() => {
           :question-type="questionConfig.type"
         />
       </div>
+
+      <QuestionValidation
+        v-if="showValidation && supportsValidation(questionConfig.type)"
+        v-model="validationModel"
+        :question-type="questionConfig.type"
+      />
     </div>
 
     <div
@@ -208,9 +262,13 @@ onMounted(() => {
           :id="`toggle-${question.id}`"
           v-model="questionConfig.required"
         />
-        <button class="flex items-center bg-sky-400 p-2 text-sm rounded-md">
+        <button
+          v-if="supportsValidation(currentQuestionOption.value)"
+          class="flex items-center bg-sky-400 hover:bg-sky-500 p-2 text-sm rounded-md"
+          @click="showValidation = !showValidation"
+        >
           <IconAdjustment class="w-5 h-5 mr-2" />
-          More Options
+          {{ showValidation ? "Hide Options" : "More Options" }}
         </button>
       </div>
 

--- a/src/components/form/question/QuestionValidation.vue
+++ b/src/components/form/question/QuestionValidation.vue
@@ -1,0 +1,171 @@
+<script lang="ts" setup>
+import { computed } from "vue";
+import type { QuestionType, QuestionValidation } from "@/types/pocketbase";
+import type { DropdownOption } from "@/types/inputs";
+
+import XDropdown from "@/components/inputs/Dropdown.vue";
+import {
+  categoryOptions,
+  conditionOptions,
+  getCondition,
+} from "@/utils/validation";
+
+const props = defineProps<{
+  modelValue: QuestionValidation | null | undefined;
+  questionType: QuestionType;
+}>();
+
+const emits = defineEmits<{
+  (e: "update:modelValue", value: QuestionValidation): void;
+}>();
+
+const categories = computed(() => categoryOptions(props.questionType));
+
+// A normalized, always-defined view of the current rule. The first time the
+// panel is used the model is null, so we fall back to the first available
+// category/condition.
+const config = computed<QuestionValidation>(() => {
+  const fallbackCategory = categories.value[0]?.value ?? "";
+  const category = props.modelValue?.category || fallbackCategory;
+  const fallbackCondition = conditionOptions(category)[0]?.value ?? "";
+  return {
+    enabled: props.modelValue?.enabled ?? false,
+    category,
+    condition: props.modelValue?.condition || fallbackCondition,
+    value: props.modelValue?.value ?? "",
+    value2: props.modelValue?.value2 ?? "",
+    errorMessage: props.modelValue?.errorMessage ?? "",
+  };
+});
+
+const conditions = computed(() => conditionOptions(config.value.category));
+
+const selectedCategory = computed<DropdownOption>(
+  () =>
+    categories.value.find((c) => c.value === config.value.category) ??
+    categories.value[0] ?? { name: "", value: "" },
+);
+
+const selectedCondition = computed<DropdownOption>(
+  () =>
+    conditions.value.find((c) => c.value === config.value.condition) ??
+    conditions.value[0] ?? { name: "", value: "" },
+);
+
+const operands = computed(
+  () => getCondition(config.value.category, config.value.condition)?.operands ?? 0,
+);
+
+const inputType = computed(() => {
+  switch (config.value.category) {
+    case "number":
+    case "length":
+    case "rating":
+    case "selection":
+      return "number";
+    case "date":
+      return "date";
+    default:
+      return "text";
+  }
+});
+
+function update(patch: Partial<QuestionValidation>) {
+  emits("update:modelValue", { ...config.value, ...patch });
+}
+
+function onCategoryChange(option: DropdownOption) {
+  // Reset the condition + operands when switching category.
+  const firstCondition = conditionOptions(option.value)[0]?.value ?? "";
+  update({
+    category: option.value,
+    condition: firstCondition,
+    value: "",
+    value2: "",
+  });
+}
+
+function onConditionChange(option: DropdownOption) {
+  update({ condition: option.value, value: "", value2: "" });
+}
+</script>
+
+<template>
+  <div
+    class="flex flex-col gap-y-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-600 rounded-md p-3 mt-2"
+  >
+    <div class="flex items-center justify-between">
+      <span class="text-sm font-medium text-neutral-700 dark:text-neutral-200">
+        Response validation
+      </span>
+      <label class="relative inline-flex items-center cursor-pointer">
+        <input
+          type="checkbox"
+          class="sr-only peer"
+          :checked="config.enabled"
+          @change="update({ enabled: !config.enabled })"
+        />
+        <div
+          class="w-9 h-5 bg-gray-200 dark:bg-neutral-600 peer-checked:bg-sky-400 rounded-full after:content-[''] after:absolute after:top-0.5 after:left-0.5 after:bg-white after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:after:translate-x-4"
+        ></div>
+      </label>
+    </div>
+
+    <template v-if="config.enabled">
+      <div>
+        <label class="block text-xs text-neutral-500 mb-1">Category</label>
+        <XDropdown
+          :model-value="selectedCategory"
+          :options="categories"
+          @update:model-value="onCategoryChange"
+        />
+      </div>
+
+      <div>
+        <label class="block text-xs text-neutral-500 mb-1">Condition</label>
+        <XDropdown
+          :model-value="selectedCondition"
+          :options="conditions"
+          @update:model-value="onConditionChange"
+        />
+      </div>
+
+      <div v-if="operands >= 1" class="flex items-center gap-x-2">
+        <input
+          :type="inputType"
+          :value="config.value"
+          @input="
+            update({ value: ($event.target as HTMLInputElement).value })
+          "
+          :placeholder="operands === 2 ? 'Min value' : 'Value'"
+          class="w-full bg-neutral-50 dark:bg-neutral-700 border border-neutral-300 dark:border-neutral-600 py-1.5 px-3 text-sm rounded-md outline-none"
+        />
+        <input
+          v-if="operands === 2"
+          :type="inputType"
+          :value="config.value2"
+          @input="
+            update({ value2: ($event.target as HTMLInputElement).value })
+          "
+          placeholder="Max value"
+          class="w-full bg-neutral-50 dark:bg-neutral-700 border border-neutral-300 dark:border-neutral-600 py-1.5 px-3 text-sm rounded-md outline-none"
+        />
+      </div>
+
+      <div>
+        <label class="block text-xs text-neutral-500 mb-1">
+          Custom error message (optional)
+        </label>
+        <input
+          type="text"
+          :value="config.errorMessage"
+          @input="
+            update({ errorMessage: ($event.target as HTMLInputElement).value })
+          "
+          placeholder="Shown when the answer is invalid"
+          class="w-full bg-neutral-50 dark:bg-neutral-700 border border-neutral-300 dark:border-neutral-600 py-1.5 px-3 text-sm rounded-md outline-none"
+        />
+      </div>
+    </template>
+  </div>
+</template>

--- a/src/components/form/question/QuestionValidation.vue
+++ b/src/components/form/question/QuestionValidation.vue
@@ -53,7 +53,8 @@ const selectedCondition = computed<DropdownOption>(
 );
 
 const operands = computed(
-  () => getCondition(config.value.category, config.value.condition)?.operands ?? 0,
+  () =>
+    getCondition(config.value.category, config.value.condition)?.operands ?? 0,
 );
 
 const inputType = computed(() => {
@@ -134,9 +135,7 @@ function onConditionChange(option: DropdownOption) {
         <input
           :type="inputType"
           :value="config.value"
-          @input="
-            update({ value: ($event.target as HTMLInputElement).value })
-          "
+          @input="update({ value: ($event.target as HTMLInputElement).value })"
           :placeholder="operands === 2 ? 'Min value' : 'Value'"
           class="w-full bg-neutral-50 dark:bg-neutral-700 border border-neutral-300 dark:border-neutral-600 py-1.5 px-3 text-sm rounded-md outline-none"
         />
@@ -144,9 +143,7 @@ function onConditionChange(option: DropdownOption) {
           v-if="operands === 2"
           :type="inputType"
           :value="config.value2"
-          @input="
-            update({ value2: ($event.target as HTMLInputElement).value })
-          "
+          @input="update({ value2: ($event.target as HTMLInputElement).value })"
           placeholder="Max value"
           class="w-full bg-neutral-50 dark:bg-neutral-700 border border-neutral-300 dark:border-neutral-600 py-1.5 px-3 text-sm rounded-md outline-none"
         />

--- a/src/components/icons/question/Date.vue
+++ b/src/components/icons/question/Date.vue
@@ -1,0 +1,13 @@
+<template>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="1em"
+    height="1em"
+    viewBox="0 0 24 24"
+  >
+    <path
+      fill="currentColor"
+      d="M19 3h-1V1h-2v2H8V1H6v2H5c-1.11 0-1.99.9-1.99 2L3 19a2 2 0 0 0 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V9h14zM5 7V5h14v2z"
+    ></path>
+  </svg>
+</template>

--- a/src/components/icons/question/Email.vue
+++ b/src/components/icons/question/Email.vue
@@ -1,0 +1,13 @@
+<template>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="1em"
+    height="1em"
+    viewBox="0 0 24 24"
+  >
+    <path
+      fill="currentColor"
+      d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 4l-8 5l-8-5V6l8 5l8-5z"
+    ></path>
+  </svg>
+</template>

--- a/src/components/icons/question/Number.vue
+++ b/src/components/icons/question/Number.vue
@@ -1,0 +1,13 @@
+<template>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="1em"
+    height="1em"
+    viewBox="0 0 24 24"
+  >
+    <path
+      fill="currentColor"
+      d="M7.78 7h1.54l-.42 2h2.04l.42-2h1.54l-.42 2H16v1.5h-1.83l-.42 2H16V14h-2.99l-.42 2h-1.54l.42-2H9.43l-.42 2H7.47l.42-2H6V12.5h2.21l.42-2H6V9h2.95zM9.74 12.5h2.04l.42-2H10.16z"
+    ></path>
+  </svg>
+</template>

--- a/src/components/icons/question/Rating.vue
+++ b/src/components/icons/question/Rating.vue
@@ -1,0 +1,13 @@
+<template>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="1em"
+    height="1em"
+    viewBox="0 0 24 24"
+  >
+    <path
+      fill="currentColor"
+      d="M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2L9.19 8.63L2 9.24l5.46 4.73L5.82 21z"
+    ></path>
+  </svg>
+</template>

--- a/src/layout/auth.vue
+++ b/src/layout/auth.vue
@@ -9,7 +9,7 @@ const settingsStore = useSettingsStore();
 
 <template>
   <main
-    class="min-h-[100dvh] bg-primary-light-100 dark:bg-primary-dark-800 text-white flex flex-col items-center justify-center"
+    class="min-h-[100dvh] bg-primary-light-100 dark:bg-primary-dark-800 text-primary-dark-800 dark:text-white flex flex-col items-center justify-center"
   >
     <div
       class="absolute top-3 right-3 flex items-center gap-x-4 sm:py-2 sm:pl-3 sm:pr-2 bg-white/70 dark:bg-black/30 sm:border border-gray-300 dark:border-gray-600 text-black dark:text-white font-medium rounded-full"

--- a/src/layout/default.vue
+++ b/src/layout/default.vue
@@ -1,6 +1,6 @@
 <template>
   <main
-    class="min-h-[100dvh] bg-primary-light-100 dark:bg-primary-dark-800 text-white flex flex-col"
+    class="min-h-[100dvh] bg-primary-light-100 dark:bg-primary-dark-800 text-primary-dark-800 dark:text-white flex flex-col"
   >
     <slot />
   </main>

--- a/src/pages/form/preview.vue
+++ b/src/pages/form/preview.vue
@@ -1,8 +1,10 @@
 <script lang="ts" setup>
-import { onMounted, ref, computed } from "vue";
-import { useRoute } from "vue-router";
+import { onMounted, ref, computed, watch } from "vue";
+import { useRoute, useRouter } from "vue-router";
 import { useTitle } from "@vueuse/core";
 import { setupParagraphInputs } from "@/utils/form";
+import { preventNonNumericInput } from "@/utils/common";
+import { validateAnswer, isEmpty } from "@/utils/validation";
 import type { AnswerValue } from "@/types/form";
 
 import { useFormStore } from "@/store/forms";
@@ -15,12 +17,18 @@ import Checkbox from "primevue/checkbox";
 import RadioButton from "primevue/radiobutton";
 
 const route = useRoute();
+const router = useRouter();
 const formStore = useFormStore();
 const questionStore = useQuestionStore();
 
 const formTitle = ref("");
 // keyed by question.id, no PocketBase persistence (preview only)
 const localAnswers = ref<Record<string, AnswerValue>>({});
+// validation errors keyed by question.id
+const errors = ref<Record<string, string>>({});
+// becomes true after the first submit attempt; gates "required" errors so empty
+// required fields don't light up red before the respondent has tried to submit.
+const submitted = ref(false);
 
 const title = computed(() => {
   const elem = document.createElement("h1");
@@ -39,7 +47,39 @@ function clearForm() {
   for (const question of questionStore.questions) {
     localAnswers.value[question.id] = getDefaultValue(question.type);
   }
+  errors.value = {};
+  submitted.value = false;
 }
+
+function validateForm(): boolean {
+  const next: Record<string, string> = {};
+  for (const question of questionStore.questions) {
+    const answer = localAnswers.value[question.id] ?? "";
+
+    // Required fields must be answered before the form can be submitted.
+    if (submitted.value && question.required && isEmpty(answer)) {
+      next[question.id] = "This field is required.";
+      continue;
+    }
+
+    const validation = question.settings?.validation;
+    if (!validation?.enabled) continue;
+    const error = validateAnswer(answer, validation);
+    if (error) next[question.id] = error;
+  }
+  errors.value = next;
+  return Object.keys(next).length === 0;
+}
+
+function submit() {
+  submitted.value = true;
+  if (!validateForm()) return;
+  router.push(`/form/${route.params.formId}/success`);
+}
+
+// Re-validate live as the respondent types into / selects answers so errors
+// surface (and clear) immediately, not only on submit.
+watch(localAnswers, () => validateForm(), { deep: true });
 
 onMounted(async () => {
   const formId = route.params.formId as string;
@@ -92,7 +132,12 @@ onMounted(async () => {
       <div
         v-for="question in questionStore.questions"
         :key="question.id"
-        class="w-full dark:bg-neutral-700 flex flex-col border border-gray-300 dark:border-transparent p-4 mx-auto shadow-md rounded-lg"
+        class="w-full dark:bg-neutral-700 flex flex-col border p-4 mx-auto shadow-md rounded-lg"
+        :class="
+          errors[question.id]
+            ? 'border-red-400'
+            : 'border-gray-300 dark:border-transparent'
+        "
       >
         <h2
           v-html="
@@ -135,6 +180,74 @@ onMounted(async () => {
               data-lpignore="true"
               class="w-full h-8 bg-transparent py-2 border-b border-gray-200 hover:border-gray-400 focus:border-sky-500 dark:placeholder:text-neutral-400 dark:text-white resize-none outline-none"
             />
+          </div>
+
+          <div
+            v-else-if="question.type === 'number'"
+            class="flex items-center gap-x-3"
+          >
+            <p class="font-rokkitt text-[26px] dark:text-sky-400">#</p>
+            <input
+              type="number"
+              v-model="localAnswers[question.id]"
+              @input="delete errors[question.id]"
+              @keydown="preventNonNumericInput"
+              placeholder="Enter a number"
+              class="w-full bg-transparent py-2 border-b border-gray-200 hover:border-gray-400 focus:border-sky-500 dark:placeholder:text-neutral-400 dark:text-white outline-none"
+              @keypress.enter.prevent
+            />
+          </div>
+
+          <div
+            v-else-if="question.type === 'email'"
+            class="flex items-center gap-x-3"
+          >
+            <p class="font-rokkitt text-[26px] dark:text-sky-400">@</p>
+            <input
+              type="email"
+              v-model="localAnswers[question.id]"
+              @input="delete errors[question.id]"
+              placeholder="email@example.com"
+              class="w-full bg-transparent py-2 border-b border-gray-200 hover:border-gray-400 focus:border-sky-500 dark:placeholder:text-neutral-400 dark:text-white outline-none"
+              @keypress.enter.prevent
+            />
+          </div>
+
+          <div
+            v-else-if="question.type === 'date'"
+            class="flex items-center gap-x-3"
+          >
+            <p class="font-rokkitt text-[26px] dark:text-sky-400">D</p>
+            <input
+              type="date"
+              v-model="localAnswers[question.id]"
+              @input="delete errors[question.id]"
+              class="w-full bg-transparent py-2 border-b border-gray-200 hover:border-gray-400 focus:border-sky-500 dark:text-white outline-none"
+            />
+          </div>
+
+          <div
+            v-else-if="question.type === 'rating'"
+            class="flex items-center gap-1"
+          >
+            <button
+              v-for="n in 5"
+              :key="n"
+              type="button"
+              @click="
+                localAnswers[question.id] = String(n);
+                delete errors[question.id];
+              "
+              class="text-3xl leading-none transition-colors"
+              :class="
+                n <= Number(localAnswers[question.id])
+                  ? 'text-yellow-400'
+                  : 'text-gray-300 hover:text-yellow-200'
+              "
+              :aria-label="`Rate ${n}`"
+            >
+              ★
+            </button>
           </div>
 
           <template
@@ -209,14 +322,19 @@ onMounted(async () => {
             </label>
           </div>
         </div>
+
+        <p v-if="errors[question.id]" class="mt-2 text-sm text-red-500">
+          {{ errors[question.id] }}
+        </p>
       </div>
 
       <div class="flex justify-between">
-        <RouterLink :to="`/form/${route.params.formId}/success`">
-          <button class="custom-btn py-2 px-5 font-medium rounded-lg">
-            Submit Form
-          </button>
-        </RouterLink>
+        <button
+          @click.prevent="submit"
+          class="custom-btn py-2 px-5 font-medium rounded-lg"
+        >
+          Submit Form
+        </button>
 
         <button
           role="button"

--- a/src/pages/form/view.vue
+++ b/src/pages/form/view.vue
@@ -6,6 +6,7 @@ import type { LocalAnswer, AnswerValue } from "@/types/form";
 import pb from "@/db/pocketBase";
 
 import debounce from "@/utils/debouncer";
+import { preventNonNumericInput } from "@/utils/common";
 import { setupParagraphInputs } from "@/utils/form";
 import { validateAnswer } from "@/utils/validation";
 
@@ -244,6 +245,7 @@ onMounted(async () => {
               type="number"
               v-model="localAnswers[question.id].value"
               @input="delete errors[question.id]"
+              @keydown="preventNonNumericInput"
               placeholder="Enter a number"
               class="w-full bg-transparent py-2 border-b border-gray-200 hover:border-gray-400 focus:border-sky-500 dark:placeholder:text-neutral-400 dark:text-white outline-none"
               @keypress.enter.prevent

--- a/src/pages/form/view.vue
+++ b/src/pages/form/view.vue
@@ -7,6 +7,7 @@ import pb from "@/db/pocketBase";
 
 import debounce from "@/utils/debouncer";
 import { setupParagraphInputs } from "@/utils/form";
+import { validateAnswer } from "@/utils/validation";
 
 import { useFormStore } from "@/store/forms";
 import { useQuestionStore } from "@/store/questions";
@@ -27,6 +28,8 @@ const formTitle = ref("");
 const responseId = ref("");
 // keyed by question.id → { recordId: response_answers.id, value }
 const localAnswers = ref<Record<string, LocalAnswer>>({});
+// validation errors keyed by question.id
+const errors = ref<Record<string, string>>({});
 
 const title = computed(() => {
   const elem = document.createElement("h1");
@@ -113,7 +116,22 @@ async function loadExistingResponse(existingResponseId: string) {
   }
 }
 
+function validateForm(): boolean {
+  const next: Record<string, string> = {};
+  for (const question of questionStore.questions) {
+    const validation = question.settings?.validation;
+    if (!validation?.enabled) continue;
+    const answer = localAnswers.value[question.id]?.value ?? "";
+    const error = validateAnswer(answer, validation);
+    if (error) next[question.id] = error;
+  }
+  errors.value = next;
+  return Object.keys(next).length === 0;
+}
+
 async function submit() {
+  if (!validateForm()) return;
+
   settingsStore.formData.is_submitted = true;
 
   await pb.collection("responses").update(responseId.value, {
@@ -163,7 +181,12 @@ onMounted(async () => {
       <div
         v-for="question in questionStore.questions"
         :key="question.id"
-        class="w-full dark:bg-neutral-700 flex flex-col border border-gray-300 dark:border-transparent p-4 mx-auto shadow-md rounded-lg"
+        class="w-full dark:bg-neutral-700 flex flex-col border p-4 mx-auto shadow-md rounded-lg"
+        :class="
+          errors[question.id]
+            ? 'border-red-400'
+            : 'border-gray-300 dark:border-transparent'
+        "
       >
         <h2
           v-html="
@@ -210,6 +233,67 @@ onMounted(async () => {
               data-lpignore="true"
               class="w-full h-8 bg-transparent py-2 border-b border-gray-200 hover:border-gray-400 focus:border-sky-500 dark:placeholder:text-neutral-400 dark:text-white resize-none outline-none"
             />
+          </div>
+
+          <div
+            v-if="question.type === 'number'"
+            class="flex items-center gap-x-3"
+          >
+            <p class="font-rokkitt text-[26px] dark:text-sky-400">#</p>
+            <input
+              type="number"
+              v-model="localAnswers[question.id].value"
+              @input="delete errors[question.id]"
+              placeholder="Enter a number"
+              class="w-full bg-transparent py-2 border-b border-gray-200 hover:border-gray-400 focus:border-sky-500 dark:placeholder:text-neutral-400 dark:text-white outline-none"
+              @keypress.enter.prevent
+            />
+          </div>
+
+          <div
+            v-if="question.type === 'email'"
+            class="flex items-center gap-x-3"
+          >
+            <p class="font-rokkitt text-[26px] dark:text-sky-400">@</p>
+            <input
+              type="email"
+              v-model="localAnswers[question.id].value"
+              @input="delete errors[question.id]"
+              placeholder="email@example.com"
+              class="w-full bg-transparent py-2 border-b border-gray-200 hover:border-gray-400 focus:border-sky-500 dark:placeholder:text-neutral-400 dark:text-white outline-none"
+              @keypress.enter.prevent
+            />
+          </div>
+
+          <div v-if="question.type === 'date'" class="flex items-center gap-x-3">
+            <p class="font-rokkitt text-[26px] dark:text-sky-400">D</p>
+            <input
+              type="date"
+              v-model="localAnswers[question.id].value"
+              @input="delete errors[question.id]"
+              class="w-full bg-transparent py-2 border-b border-gray-200 hover:border-gray-400 focus:border-sky-500 dark:text-white outline-none"
+            />
+          </div>
+
+          <div v-if="question.type === 'rating'" class="flex items-center gap-1">
+            <button
+              v-for="n in 5"
+              :key="n"
+              type="button"
+              @click="
+                localAnswers[question.id].value = String(n);
+                delete errors[question.id];
+              "
+              class="text-3xl leading-none transition-colors"
+              :class="
+                n <= Number(localAnswers[question.id].value)
+                  ? 'text-yellow-400'
+                  : 'text-gray-300 hover:text-yellow-200'
+              "
+              :aria-label="`Rate ${n}`"
+            >
+              ★
+            </button>
           </div>
 
           <template
@@ -284,6 +368,10 @@ onMounted(async () => {
             </label>
           </div>
         </div>
+
+        <p v-if="errors[question.id]" class="mt-2 text-sm text-red-500">
+          {{ errors[question.id] }}
+        </p>
       </div>
 
       <div class="flex justify-between">

--- a/src/pages/form/view.vue
+++ b/src/pages/form/view.vue
@@ -265,7 +265,10 @@ onMounted(async () => {
             />
           </div>
 
-          <div v-if="question.type === 'date'" class="flex items-center gap-x-3">
+          <div
+            v-if="question.type === 'date'"
+            class="flex items-center gap-x-3"
+          >
             <p class="font-rokkitt text-[26px] dark:text-sky-400">D</p>
             <input
               type="date"
@@ -275,7 +278,10 @@ onMounted(async () => {
             />
           </div>
 
-          <div v-if="question.type === 'rating'" class="flex items-center gap-1">
+          <div
+            v-if="question.type === 'rating'"
+            class="flex items-center gap-1"
+          >
             <button
               v-for="n in 5"
               :key="n"

--- a/src/style.css
+++ b/src/style.css
@@ -26,6 +26,14 @@
 /* General styles */
 body {
   font-family: "Inter", sans-serif;
+  /* Universal text color — defined once here for both themes instead of
+     repeating `dark:text-white` on every element. Light mode gets near-black
+     text, dark mode gets white; per-element overrides still win where needed. */
+  color: var(--color-primary-dark-800);
+}
+
+.dark body {
+  color: #ffffff;
 }
 
 .container {

--- a/src/types/pocketbase.d.ts
+++ b/src/types/pocketbase.d.ts
@@ -14,19 +14,41 @@ export interface QuestionChoice extends BaseCollectionType {
   order: number;
 }
 
+export type QuestionType =
+  | "short_text"
+  | "long_text"
+  | "single_choice"
+  | "multiple_choice"
+  | "dropdown"
+  | "linear_scale"
+  | "number"
+  | "email"
+  | "date"
+  | "rating";
+
+export interface QuestionValidation {
+  enabled: boolean;
+  category: string; // key into VALIDATION_RULES, e.g. "number", "text"
+  condition: string; // condition key, e.g. "gt", "atLeast"
+  value: string; // primary operand
+  value2?: string; // upper bound for between / notBetween
+  errorMessage: string; // optional custom message shown to the respondent
+}
+
+// Per-question settings blob persisted as a single JSON field on the
+// `questions` collection. Validation config lives here so it stays grouped with
+// future per-question options.
+export interface QuestionSettings {
+  validation?: QuestionValidation | null;
+}
+
 export interface Question extends BaseCollectionType {
   label: string;
   description: string;
-  type:
-    | "short_text"
-    | "long_text"
-    | "single_choice"
-    | "multiple_choice"
-    | "dropdown"
-    | "linear_scale";
+  type: QuestionType;
   order: number;
   required: boolean;
-  settings: Record<string, unknown>;
+  settings: QuestionSettings;
   form: string;
   expand?: {
     question_choices: QuestionChoice[];

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -1,3 +1,16 @@
 export function trunc(str: string, length: number = 5, fill: string = "..") {
   return str.slice(0, length) + fill;
 }
+
+// Block non-numeric keys (letters, scientific notation, etc.) on number inputs.
+// Allows digits, a single decimal point, a leading sign, and control keys.
+export function preventNonNumericInput(event: KeyboardEvent) {
+  // Let control/navigation keys and shortcuts through.
+  if (event.key.length > 1 || event.ctrlKey || event.metaKey || event.altKey) {
+    return;
+  }
+
+  if (!/[0-9.+-]/.test(event.key)) {
+    event.preventDefault();
+  }
+}

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,0 +1,301 @@
+import type {
+  QuestionType,
+  QuestionValidation,
+} from "@/types/pocketbase";
+import type { DropdownOption } from "@/types/inputs";
+
+// ── Registry ────────────────────────────────────────────────────────────────
+// Single source of truth for every validation category, its conditions and how
+// many operands each condition needs. Drives both the config dropdowns and the
+// validateAnswer() runtime check.
+
+export type ValidationCondition = {
+  value: string;
+  name: string;
+  operands: 0 | 1 | 2;
+};
+
+export type ValidationCategoryDef = {
+  name: string;
+  conditions: ValidationCondition[];
+};
+
+export const VALIDATION_RULES: Record<string, ValidationCategoryDef> = {
+  number: {
+    name: "Number",
+    conditions: [
+      { value: "gt", name: "Greater than", operands: 1 },
+      { value: "gte", name: "Greater than or equal to", operands: 1 },
+      { value: "lt", name: "Less than", operands: 1 },
+      { value: "lte", name: "Less than or equal to", operands: 1 },
+      { value: "eq", name: "Equal to", operands: 1 },
+      { value: "neq", name: "Not equal to", operands: 1 },
+      { value: "between", name: "Between", operands: 2 },
+      { value: "notBetween", name: "Not between", operands: 2 },
+      { value: "isNumber", name: "Is number", operands: 0 },
+      { value: "wholeNumber", name: "Whole number", operands: 0 },
+    ],
+  },
+  text: {
+    name: "Text",
+    conditions: [
+      { value: "contains", name: "Contains", operands: 1 },
+      { value: "notContains", name: "Doesn't contain", operands: 1 },
+    ],
+  },
+  length: {
+    name: "Length",
+    conditions: [
+      { value: "maxLength", name: "Maximum character count", operands: 1 },
+      { value: "minLength", name: "Minimum character count", operands: 1 },
+    ],
+  },
+  regex: {
+    name: "Regular Expression",
+    conditions: [
+      { value: "contains", name: "Contains", operands: 1 },
+      { value: "notContains", name: "Doesn't contain", operands: 1 },
+      { value: "matches", name: "Matches", operands: 1 },
+      { value: "notMatches", name: "Doesn't match", operands: 1 },
+    ],
+  },
+  email: {
+    name: "Email",
+    conditions: [{ value: "isEmail", name: "Valid email", operands: 0 }],
+  },
+  date: {
+    name: "Date",
+    conditions: [
+      { value: "onOrAfter", name: "On or after", operands: 1 },
+      { value: "onOrBefore", name: "On or before", operands: 1 },
+      { value: "between", name: "Between", operands: 2 },
+      { value: "notBetween", name: "Not between", operands: 2 },
+    ],
+  },
+  rating: {
+    name: "Rating",
+    conditions: [
+      { value: "min", name: "At least", operands: 1 },
+      { value: "max", name: "At most", operands: 1 },
+    ],
+  },
+  selection: {
+    name: "Selection",
+    conditions: [
+      { value: "atLeast", name: "Select at least", operands: 1 },
+      { value: "atMost", name: "Select at most", operands: 1 },
+      { value: "exactly", name: "Select exactly", operands: 1 },
+    ],
+  },
+};
+
+// Which validation categories apply to each question type. Types absent from
+// this map (single_choice, dropdown, linear_scale) have no configurable
+// validation beyond the existing `required` flag.
+export const TYPE_CATEGORIES: Partial<Record<QuestionType, string[]>> = {
+  short_text: ["text", "length", "regex"],
+  long_text: ["text", "length", "regex"],
+  number: ["number"],
+  email: ["email"],
+  date: ["date"],
+  rating: ["rating"],
+  multiple_choice: ["selection"],
+};
+
+export function supportsValidation(type: QuestionType): boolean {
+  return (TYPE_CATEGORIES[type]?.length ?? 0) > 0;
+}
+
+// ── Dropdown option builders ─────────────────────────────────────────────────
+
+export function categoryOptions(type: QuestionType): DropdownOption[] {
+  return (TYPE_CATEGORIES[type] ?? []).map((category) => ({
+    name: VALIDATION_RULES[category]?.name ?? category,
+    value: category,
+  }));
+}
+
+export function conditionOptions(category: string): DropdownOption[] {
+  return (VALIDATION_RULES[category]?.conditions ?? []).map((condition) => ({
+    name: condition.name,
+    value: condition.value,
+  }));
+}
+
+export function getCondition(
+  category: string,
+  conditionValue: string,
+): ValidationCondition | undefined {
+  return VALIDATION_RULES[category]?.conditions.find(
+    (condition) => condition.value === conditionValue,
+  );
+}
+
+// ── Runtime validation ───────────────────────────────────────────────────────
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function isEmpty(answer: unknown): boolean {
+  if (Array.isArray(answer)) return answer.length === 0;
+  return answer === null || answer === undefined || answer === "";
+}
+
+function safeRegex(pattern: string): RegExp | null {
+  try {
+    return new RegExp(pattern);
+  } catch {
+    return null;
+  }
+}
+
+function checkNumber(
+  answer: string,
+  condition: string,
+  a: number,
+  b: number,
+): boolean {
+  const n = Number(answer);
+  switch (condition) {
+    case "gt":
+      return n > a;
+    case "gte":
+      return n >= a;
+    case "lt":
+      return n < a;
+    case "lte":
+      return n <= a;
+    case "eq":
+      return n === a;
+    case "neq":
+      return n !== a;
+    case "between":
+      return n >= Math.min(a, b) && n <= Math.max(a, b);
+    case "notBetween":
+      return n < Math.min(a, b) || n > Math.max(a, b);
+    case "isNumber":
+      return answer.trim() !== "" && !Number.isNaN(n);
+    case "wholeNumber":
+      return Number.isInteger(n);
+    default:
+      return true;
+  }
+}
+
+function checkDate(
+  answer: string,
+  condition: string,
+  v: string,
+  v2: string,
+): boolean {
+  const t = new Date(answer).getTime();
+  const a = new Date(v).getTime();
+  const b = new Date(v2).getTime();
+  if (Number.isNaN(t)) return false;
+  switch (condition) {
+    case "onOrAfter":
+      return t >= a;
+    case "onOrBefore":
+      return t <= a;
+    case "between":
+      return t >= Math.min(a, b) && t <= Math.max(a, b);
+    case "notBetween":
+      return t < Math.min(a, b) || t > Math.max(a, b);
+    default:
+      return true;
+  }
+}
+
+/**
+ * Validate a single answer against a question's validation rule.
+ * Returns null when valid (or when there's nothing to check), otherwise the
+ * error message to display. Empty answers always pass here — emptiness is the
+ * `required` flag's responsibility.
+ */
+export function validateAnswer(
+  answer: string | string[],
+  validation: QuestionValidation | null | undefined,
+): string | null {
+  if (!validation?.enabled) return null;
+  if (isEmpty(answer)) return null;
+
+  const { category, condition, value, value2 = "", errorMessage } = validation;
+  let valid = true;
+
+  switch (category) {
+    case "number": {
+      valid = checkNumber(
+        String(answer),
+        condition,
+        Number(value),
+        Number(value2),
+      );
+      break;
+    }
+    case "length": {
+      const len = String(answer).length;
+      const n = Number(value);
+      valid = condition === "maxLength" ? len <= n : len >= n;
+      break;
+    }
+    case "text": {
+      const has = String(answer).includes(value);
+      valid = condition === "notContains" ? !has : has;
+      break;
+    }
+    case "email": {
+      valid = EMAIL_RE.test(String(answer));
+      break;
+    }
+    case "date": {
+      valid = checkDate(String(answer), condition, value, value2);
+      break;
+    }
+    case "rating": {
+      const n = Number(answer);
+      valid = condition === "min" ? n >= Number(value) : n <= Number(value);
+      break;
+    }
+    case "selection": {
+      const count = Array.isArray(answer) ? answer.length : answer ? 1 : 0;
+      const n = Number(value);
+      if (condition === "atLeast") valid = count >= n;
+      else if (condition === "atMost") valid = count <= n;
+      else valid = count === n; // exactly
+      break;
+    }
+    case "regex": {
+      const re = safeRegex(
+        condition === "matches" || condition === "notMatches"
+          ? `^(?:${value})$`
+          : value,
+      );
+      if (!re) {
+        valid = true; // invalid pattern never hard-blocks the respondent
+        break;
+      }
+      const matched = re.test(String(answer));
+      valid =
+        condition === "notContains" || condition === "notMatches"
+          ? !matched
+          : matched;
+      break;
+    }
+    default:
+      valid = true;
+  }
+
+  if (valid) return null;
+  return errorMessage?.trim() || defaultMessage(validation);
+}
+
+function defaultMessage(v: QuestionValidation): string {
+  const condition = getCondition(v.category, v.condition);
+  const label = condition?.name ?? v.condition;
+  const operand =
+    condition?.operands === 2
+      ? `${v.value} and ${v.value2 ?? ""}`
+      : (v.value ?? "");
+  return condition?.operands === 0
+    ? `This answer must be a ${label.toLowerCase()}.`
+    : `This answer must satisfy: ${label} ${operand}`.trim();
+}

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -132,7 +132,7 @@ export function getCondition(
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
-function isEmpty(answer: unknown): boolean {
+export function isEmpty(answer: unknown): boolean {
   if (Array.isArray(answer)) return answer.length === 0;
   return answer === null || answer === undefined || answer === "";
 }

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,7 +1,4 @@
-import type {
-  QuestionType,
-  QuestionValidation,
-} from "@/types/pocketbase";
+import type { QuestionType, QuestionValidation } from "@/types/pocketbase";
 import type { DropdownOption } from "@/types/inputs";
 
 // ── Registry ────────────────────────────────────────────────────────────────

--- a/tests/validation.spec.ts
+++ b/tests/validation.spec.ts
@@ -1,0 +1,699 @@
+import { test, expect, type Page } from "@playwright/test";
+import type {
+  Question,
+  QuestionType,
+  QuestionValidation,
+} from "../src/types/pocketbase";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Question-validation E2E
+//
+// Exercises validateAnswer() (src/utils/validation.ts) end-to-end through the
+// form preview page (src/pages/form/preview.vue), which renders one input per
+// question type and surfaces validation errors live as the respondent types.
+//
+// Rather than provisioning real PocketBase records, each test mocks the three
+// GET endpoints the preview page reads (forms, questions, question_choices) and
+// injects a structurally-valid (but fake) PocketBase session so the
+// auth-guarded /form/:id/preview route renders. No network writes, no account,
+// no cleanup — fully deterministic and CI-safe.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const FORM_ID = "e2e-validation-form";
+
+// The preview page reads `pb.authStore.isValid`, which decodes the JWT in
+// localStorage["pocketbase_auth"] and checks its `exp`. A token with a
+// far-future exp passes the guard without any real auth request — every data
+// fetch is mocked below, so the token is never sent anywhere.
+function injectFakeAuth(page: Page) {
+  return page.addInitScript(() => {
+    const payload = {
+      exp: 9999999999, // year 2286 — never "expired"
+      id: "e2e-user",
+      type: "auth",
+      collectionId: "_pb_users_auth_",
+    };
+    const token = `x.${btoa(JSON.stringify(payload))}.y`;
+    localStorage.setItem(
+      "pocketbase_auth",
+      JSON.stringify({
+        token,
+        record: {
+          id: "e2e-user",
+          email: "e2e@formjam.test",
+          collectionName: "users",
+        },
+      }),
+    );
+  });
+}
+
+type QuestionChoiceSeed = { id: string; label: string };
+
+type QuestionSeed = {
+  type: QuestionType;
+  validation: QuestionValidation;
+  required?: boolean;
+  choices?: QuestionChoiceSeed[];
+};
+
+// PocketBase list-response envelope (getList / getFullList both expect it).
+function listBody(items: unknown[]) {
+  return JSON.stringify({
+    page: 1,
+    perPage: 500,
+    totalItems: items.length,
+    totalPages: 1,
+    items,
+  });
+}
+
+function buildQuestion(seed: QuestionSeed, index: number): Question {
+  return {
+    id: `q-${index}`,
+    label: `Question ${index + 1}`,
+    description: "",
+    type: seed.type,
+    order: index + 1,
+    required: seed.required ?? false,
+    settings: { validation: seed.validation },
+    form: FORM_ID,
+    created: "",
+    updated: "",
+    collectionId: "questions",
+    collectionName: "questions",
+  };
+}
+
+// Mocks the forms / questions / question_choices reads the preview page issues
+// on mount, then navigates to the preview route for the given questions.
+async function gotoPreview(page: Page, seeds: QuestionSeed[]) {
+  const questions = seeds.map(buildQuestion);
+
+  const choices = seeds.flatMap((seed, i) =>
+    (seed.choices ?? []).map((choice, order) => ({
+      id: choice.id,
+      label: choice.label,
+      order: order + 1,
+      question: `q-${i}`,
+      created: "",
+      updated: "",
+      collectionId: "question_choices",
+      collectionName: "question_choices",
+    })),
+  );
+
+  await page.route(/\/api\/collections\/forms\/records/, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: listBody([
+        {
+          id: FORM_ID,
+          title: "Validation Test Form",
+          description: "",
+          status: "published",
+          view_mode: "list",
+          starred: false,
+          slug: "e2e-validation",
+          settings: {},
+          user: "e2e-user",
+          created: "",
+          updated: "",
+          collectionId: "forms",
+          collectionName: "forms",
+        },
+      ]),
+    }),
+  );
+
+  await page.route(/\/api\/collections\/questions\/records/, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: listBody(questions),
+    }),
+  );
+
+  await page.route(/\/api\/collections\/question_choices\/records/, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: listBody(choices),
+    }),
+  );
+
+  await page.goto(`/form/${FORM_ID}/preview`);
+  await expect(page).toHaveURL(/\/preview/);
+}
+
+// Single error <p> on the page (each test mocks exactly one question, so the
+// `.text-red-500` paragraph is unambiguous — the required asterisk is a <span>).
+function errorMessage(page: Page) {
+  return page.locator("p.text-red-500");
+}
+
+// Submitting runs validateForm() and gates navigation. We assert through Submit
+// rather than the live `watch`, because the number/email/date inputs clear their
+// error on every `@input`, which races the live re-validation. Submit is the
+// single, reliable trigger across all types — and verifies the submit gate too.
+async function expectInvalid(page: Page, message: string) {
+  await page.getByRole("button", { name: "Submit Form" }).click();
+  await expect(page).toHaveURL(/\/preview/); // submit blocked
+  await expect(errorMessage(page)).toHaveText(message);
+}
+
+// Once a valid answer is entered the error clears live (via the input's @input
+// handler or the localAnswers watcher), so no resubmit is needed.
+async function expectValid(page: Page) {
+  await expect(errorMessage(page)).toBeHidden();
+}
+
+test.beforeEach(async ({ page }) => {
+  await injectFakeAuth(page);
+});
+
+// ── Text-input categories (short_text / long_text): text, length, regex ──────
+
+const TEXT_INPUTS: { type: QuestionType; selector: string }[] = [
+  { type: "short_text", selector: 'input[type="text"]' },
+  { type: "long_text", selector: "textarea" },
+];
+
+for (const { type, selector } of TEXT_INPUTS) {
+  test.describe(`${type} validation`, () => {
+    test("text: contains", async ({ page }) => {
+      await gotoPreview(page, [
+        {
+          type,
+          validation: {
+            enabled: true,
+            category: "text",
+            condition: "contains",
+            value: "@",
+            errorMessage: "Must contain an @ symbol",
+          },
+        },
+      ]);
+
+      await page.locator(selector).fill("no symbol here");
+      await expectInvalid(page, "Must contain an @ symbol");
+
+      await page.locator(selector).fill("has @ symbol");
+      await expectValid(page);
+    });
+
+    test("text: notContains", async ({ page }) => {
+      await gotoPreview(page, [
+        {
+          type,
+          validation: {
+            enabled: true,
+            category: "text",
+            condition: "notContains",
+            value: "spam",
+            errorMessage: "Must not contain 'spam'",
+          },
+        },
+      ]);
+
+      await page.locator(selector).fill("this is spam!");
+      await expectInvalid(page, "Must not contain 'spam'");
+
+      await page.locator(selector).fill("this is fine");
+      await expectValid(page);
+    });
+
+    test("length: minLength", async ({ page }) => {
+      await gotoPreview(page, [
+        {
+          type,
+          validation: {
+            enabled: true,
+            category: "length",
+            condition: "minLength",
+            value: "5",
+            errorMessage: "At least 5 characters",
+          },
+        },
+      ]);
+
+      await page.locator(selector).fill("abc");
+      await expectInvalid(page, "At least 5 characters");
+
+      await page.locator(selector).fill("abcdef");
+      await expectValid(page);
+    });
+
+    test("length: maxLength", async ({ page }) => {
+      await gotoPreview(page, [
+        {
+          type,
+          validation: {
+            enabled: true,
+            category: "length",
+            condition: "maxLength",
+            value: "5",
+            errorMessage: "At most 5 characters",
+          },
+        },
+      ]);
+
+      await page.locator(selector).fill("way too long");
+      await expectInvalid(page, "At most 5 characters");
+
+      await page.locator(selector).fill("short");
+      await expectValid(page);
+    });
+
+    test("regex: matches", async ({ page }) => {
+      await gotoPreview(page, [
+        {
+          type,
+          validation: {
+            enabled: true,
+            category: "regex",
+            condition: "matches",
+            value: "[0-9]{3}",
+            errorMessage: "Must be exactly 3 digits",
+          },
+        },
+      ]);
+
+      // matches anchors the pattern (^(?:...)$), so partial/invalid input fails.
+      await page.locator(selector).fill("12");
+      await expectInvalid(page, "Must be exactly 3 digits");
+
+      await page.locator(selector).fill("123");
+      await expectValid(page);
+    });
+
+    test("regex: notMatches", async ({ page }) => {
+      await gotoPreview(page, [
+        {
+          type,
+          validation: {
+            enabled: true,
+            category: "regex",
+            condition: "notMatches",
+            value: "[0-9]+",
+            errorMessage: "Digits only is not allowed",
+          },
+        },
+      ]);
+
+      await page.locator(selector).fill("4567");
+      await expectInvalid(page, "Digits only is not allowed");
+
+      await page.locator(selector).fill("letters");
+      await expectValid(page);
+    });
+  });
+}
+
+// ── number ───────────────────────────────────────────────────────────────────
+
+test.describe("number validation", () => {
+  const input = 'input[type="number"]';
+
+  test("greater than", async ({ page }) => {
+    await gotoPreview(page, [
+      {
+        type: "number",
+        validation: {
+          enabled: true,
+          category: "number",
+          condition: "gt",
+          value: "10",
+          errorMessage: "Must be greater than 10",
+        },
+      },
+    ]);
+
+    await page.locator(input).fill("10");
+    await expectInvalid(page, "Must be greater than 10");
+
+    await page.locator(input).fill("11");
+    await expectValid(page);
+  });
+
+  test("less than or equal to", async ({ page }) => {
+    await gotoPreview(page, [
+      {
+        type: "number",
+        validation: {
+          enabled: true,
+          category: "number",
+          condition: "lte",
+          value: "100",
+          errorMessage: "Must be at most 100",
+        },
+      },
+    ]);
+
+    await page.locator(input).fill("101");
+    await expectInvalid(page, "Must be at most 100");
+
+    await page.locator(input).fill("100");
+    await expectValid(page);
+  });
+
+  test("equal to", async ({ page }) => {
+    await gotoPreview(page, [
+      {
+        type: "number",
+        validation: {
+          enabled: true,
+          category: "number",
+          condition: "eq",
+          value: "42",
+          errorMessage: "Must equal 42",
+        },
+      },
+    ]);
+
+    await page.locator(input).fill("41");
+    await expectInvalid(page, "Must equal 42");
+
+    await page.locator(input).fill("42");
+    await expectValid(page);
+  });
+
+  test("between", async ({ page }) => {
+    await gotoPreview(page, [
+      {
+        type: "number",
+        validation: {
+          enabled: true,
+          category: "number",
+          condition: "between",
+          value: "18",
+          value2: "65",
+          errorMessage: "Must be between 18 and 65",
+        },
+      },
+    ]);
+
+    await page.locator(input).fill("17");
+    await expectInvalid(page, "Must be between 18 and 65");
+
+    await page.locator(input).fill("30");
+    await expectValid(page);
+  });
+
+  test("whole number", async ({ page }) => {
+    await gotoPreview(page, [
+      {
+        type: "number",
+        validation: {
+          enabled: true,
+          category: "number",
+          condition: "wholeNumber",
+          value: "",
+          errorMessage: "Must be a whole number",
+        },
+      },
+    ]);
+
+    await page.locator(input).fill("2.5");
+    await expectInvalid(page, "Must be a whole number");
+
+    await page.locator(input).fill("3");
+    await expectValid(page);
+  });
+});
+
+// ── email ────────────────────────────────────────────────────────────────────
+
+test.describe("email validation", () => {
+  test("isEmail", async ({ page }) => {
+    await gotoPreview(page, [
+      {
+        type: "email",
+        validation: {
+          enabled: true,
+          category: "email",
+          condition: "isEmail",
+          value: "",
+          errorMessage: "Enter a valid email address",
+        },
+      },
+    ]);
+
+    const input = 'input[type="email"]';
+    await page.locator(input).fill("not-an-email");
+    await expectInvalid(page, "Enter a valid email address");
+
+    await page.locator(input).fill("user@example.com");
+    await expectValid(page);
+  });
+});
+
+// ── date ─────────────────────────────────────────────────────────────────────
+
+test.describe("date validation", () => {
+  const input = 'input[type="date"]';
+
+  test("on or after", async ({ page }) => {
+    await gotoPreview(page, [
+      {
+        type: "date",
+        validation: {
+          enabled: true,
+          category: "date",
+          condition: "onOrAfter",
+          value: "2026-01-01",
+          errorMessage: "Must be on or after 2026-01-01",
+        },
+      },
+    ]);
+
+    await page.locator(input).fill("2025-12-31");
+    await expectInvalid(page, "Must be on or after 2026-01-01");
+
+    await page.locator(input).fill("2026-06-01");
+    await expectValid(page);
+  });
+
+  test("between", async ({ page }) => {
+    await gotoPreview(page, [
+      {
+        type: "date",
+        validation: {
+          enabled: true,
+          category: "date",
+          condition: "between",
+          value: "2026-01-01",
+          value2: "2026-12-31",
+          errorMessage: "Must be within 2026",
+        },
+      },
+    ]);
+
+    await page.locator(input).fill("2027-03-15");
+    await expectInvalid(page, "Must be within 2026");
+
+    await page.locator(input).fill("2026-07-04");
+    await expectValid(page);
+  });
+});
+
+// ── rating ───────────────────────────────────────────────────────────────────
+
+test.describe("rating validation", () => {
+  const star = (n: number) => `button[aria-label="Rate ${n}"]`;
+
+  test("at least", async ({ page }) => {
+    await gotoPreview(page, [
+      {
+        type: "rating",
+        validation: {
+          enabled: true,
+          category: "rating",
+          condition: "min",
+          value: "3",
+          errorMessage: "Please rate at least 3 stars",
+        },
+      },
+    ]);
+
+    await page.locator(star(2)).click();
+    await expectInvalid(page, "Please rate at least 3 stars");
+
+    await page.locator(star(4)).click();
+    await expectValid(page);
+  });
+
+  test("at most", async ({ page }) => {
+    await gotoPreview(page, [
+      {
+        type: "rating",
+        validation: {
+          enabled: true,
+          category: "rating",
+          condition: "max",
+          value: "3",
+          errorMessage: "Please rate at most 3 stars",
+        },
+      },
+    ]);
+
+    await page.locator(star(5)).click();
+    await expectInvalid(page, "Please rate at most 3 stars");
+
+    await page.locator(star(2)).click();
+    await expectValid(page);
+  });
+});
+
+// ── multiple_choice (selection) ──────────────────────────────────────────────
+
+test.describe("multiple_choice (selection) validation", () => {
+  const choices = [
+    { id: "c-1", label: "Option A" },
+    { id: "c-2", label: "Option B" },
+    { id: "c-3", label: "Option C" },
+  ];
+  // PrimeVue Checkbox renders a hidden input with input-id=choice.id; toggle via
+  // the associated <label for="choice.id">.
+  const choice = (id: string) => `label[for="${id}"]`;
+
+  test("select at least", async ({ page }) => {
+    await gotoPreview(page, [
+      {
+        type: "multiple_choice",
+        choices,
+        validation: {
+          enabled: true,
+          category: "selection",
+          condition: "atLeast",
+          value: "2",
+          errorMessage: "Select at least 2 options",
+        },
+      },
+    ]);
+
+    await page.locator(choice("c-1")).click();
+    await expectInvalid(page, "Select at least 2 options");
+
+    await page.locator(choice("c-2")).click();
+    await expectValid(page);
+  });
+
+  test("select at most", async ({ page }) => {
+    await gotoPreview(page, [
+      {
+        type: "multiple_choice",
+        choices,
+        validation: {
+          enabled: true,
+          category: "selection",
+          condition: "atMost",
+          value: "1",
+          errorMessage: "Select at most 1 option",
+        },
+      },
+    ]);
+
+    await page.locator(choice("c-1")).click();
+    await page.locator(choice("c-2")).click();
+    await expectInvalid(page, "Select at most 1 option");
+
+    await page.locator(choice("c-2")).click(); // deselect back to 1
+    await expectValid(page);
+  });
+
+  test("select exactly", async ({ page }) => {
+    await gotoPreview(page, [
+      {
+        type: "multiple_choice",
+        choices,
+        validation: {
+          enabled: true,
+          category: "selection",
+          condition: "exactly",
+          value: "2",
+          errorMessage: "Select exactly 2 options",
+        },
+      },
+    ]);
+
+    await page.locator(choice("c-1")).click();
+    await expectInvalid(page, "Select exactly 2 options");
+
+    await page.locator(choice("c-2")).click();
+    await expectValid(page);
+  });
+});
+
+// ── default (no custom message) + submit gating ──────────────────────────────
+
+test.describe("validation behavior", () => {
+  test("falls back to a generated message when none is provided", async ({
+    page,
+  }) => {
+    await gotoPreview(page, [
+      {
+        type: "number",
+        validation: {
+          enabled: true,
+          category: "number",
+          condition: "gt",
+          value: "10",
+          errorMessage: "", // no custom message → defaultMessage()
+        },
+      },
+    ]);
+
+    await page.locator('input[type="number"]').fill("5");
+    await expectInvalid(page, "This answer must satisfy: Greater than 10");
+  });
+
+  test("empty answer passes (emptiness is the required flag's job)", async ({
+    page,
+  }) => {
+    await gotoPreview(page, [
+      {
+        type: "short_text",
+        validation: {
+          enabled: true,
+          category: "length",
+          condition: "minLength",
+          value: "5",
+          errorMessage: "At least 5 characters",
+        },
+      },
+    ]);
+
+    // Too short → error, then clear — an empty value must not trigger the rule.
+    await page.locator('input[type="text"]').fill("ab");
+    await expectInvalid(page, "At least 5 characters");
+    await page.locator('input[type="text"]').fill("");
+    await expectValid(page);
+  });
+
+  test("invalid answer blocks submit; valid answer navigates to success", async ({
+    page,
+  }) => {
+    await gotoPreview(page, [
+      {
+        type: "number",
+        validation: {
+          enabled: true,
+          category: "number",
+          condition: "between",
+          value: "1",
+          value2: "5",
+          errorMessage: "Pick a number from 1 to 5",
+        },
+      },
+    ]);
+
+    await page.locator('input[type="number"]').fill("9");
+    await expectInvalid(page, "Pick a number from 1 to 5"); // submit blocked
+
+    await page.locator('input[type="number"]').fill("3");
+    await page.getByRole("button", { name: "Submit Form" }).click();
+    await expect(page).toHaveURL(/\/success/);
+  });
+});


### PR DESCRIPTION
Add a registry-driven response-validation system covering all question types, configurable via the previously-inert "More Options" panel and enforced on form submission.

- New question types: number, email, date, rating (icons, builder previews, viewer rendering with an interactive star widget)
- VALIDATION_RULES + TYPE_CATEGORIES registry and validateAnswer() in src/utils/validation.ts (Number/Text/Length/Regex/Email/Date/Rating/ Selection categories)
- QuestionValidation.vue inline expandable config panel
- Validation persisted under the question's settings JSON
- view.vue gates submit() on validateForm(), showing per-question errors

Note: requires a `settings` JSON field on the PocketBase questions collection and the type field's allowed values widened to include number/email/date/rating (no pb_migrations in repo).