### PR TITLE
Add form responses dashboard with analytics views

### DIFF
--- a/src/components/form/FormNavbar.vue
+++ b/src/components/form/FormNavbar.vue
@@ -1,21 +1,58 @@
 <script lang="ts" setup>
-import { computed, ref } from "vue";
+import { computed, onMounted, ref } from "vue";
 import { useRoute } from "vue-router";
 
 import { useFormStore } from "@/store/forms";
 import { useQuestionStore } from "@/store/questions";
+import { useSettingsStore } from "@/store/settings";
 
 import IconEyeOpen from "@/components/icons/input/EyeOpen.vue";
+import IconShareLink from "@/components/icons/controls/ShareLink.vue";
 import ThemeToggle from "@/components/common/ThemeToggle.vue";
 
 const route = useRoute();
 const formStore = useFormStore();
 const questionStore = useQuestionStore();
+const settingsStore = useSettingsStore();
 
-const currentSection = ref("Questions");
+const formId = computed(() => route.params.formId as string);
+
+const currentForm = computed(() =>
+  formStore.forms.find((form) => form.id === formId.value),
+);
+const isPublished = computed(() => currentForm.value?.status === "published");
+
 function setSection(section: string) {
-  currentSection.value = section;
+  settingsStore.formSections.editSection = section;
 }
+
+async function togglePublish() {
+  await formStore.setStatus(
+    formId.value,
+    isPublished.value ? "draft" : "published",
+  );
+}
+
+const shareUrl = computed(
+  () => `${window.location.origin}/form/${formId.value}/view`,
+);
+
+const copied = ref(false);
+async function copyShareLink() {
+  if (!isPublished.value) return;
+  try {
+    await navigator.clipboard.writeText(shareUrl.value);
+  } catch {
+    // Clipboard unavailable (e.g. insecure context) — fall back to a prompt.
+    window.prompt("Copy this link:", shareUrl.value);
+  }
+  copied.value = true;
+  setTimeout(() => (copied.value = false), 2000);
+}
+
+onMounted(() => {
+  if (!currentForm.value) formStore.fetchForm(formId.value);
+});
 
 const saveStatus = computed(() => {
   if (
@@ -99,19 +136,62 @@ const saveStatus = computed(() => {
       </div>
 
       <ThemeToggle class="ml-auto mr-3" />
-      <RouterLink
+
+      <div
         v-if="route.name === 'EditForm'"
-        :to="`/form/${route.params.formId}/preview`"
+        class="flex items-center gap-x-2"
       >
+        <!-- Share link -->
         <button
-          title="View Form"
-          class="custom-btn flex gap-x-2 p-2 rounded-lg"
-          data-cy="preview_btn"
+          type="button"
+          :disabled="!isPublished"
+          :title="
+            isPublished
+              ? 'Copy shareable link'
+              : 'Publish your form to share it'
+          "
+          class="flex items-center gap-x-2 rounded-lg border border-gray-300 p-2 text-neutral-700 transition enabled:hover:border-sky-400 enabled:hover:text-sky-500 disabled:cursor-not-allowed disabled:opacity-40 dark:border-neutral-600 dark:text-white"
+          data-cy="share_btn"
+          @click="copyShareLink"
         >
-          <IconEyeOpen class="w-6 h-6 sm:mr-1" />
-          <span class="hidden sm:block"> Preview </span>
+          <IconShareLink class="w-5 h-5" />
+          <span class="hidden sm:block">
+            {{ copied ? "Copied!" : "Share" }}
+          </span>
         </button>
-      </RouterLink>
+
+        <!-- Publish toggle -->
+        <button
+          type="button"
+          :title="isPublished ? 'Unpublish form' : 'Publish form'"
+          class="flex items-center gap-x-2 rounded-lg p-2 font-medium transition"
+          :class="
+            isPublished
+              ? 'bg-emerald-100 text-emerald-700 hover:bg-emerald-200 dark:bg-emerald-500/15 dark:text-emerald-400'
+              : 'custom-btn'
+          "
+          data-cy="publish_btn"
+          @click="togglePublish"
+        >
+          <span
+            v-if="isPublished"
+            class="h-2 w-2 rounded-full bg-emerald-500"
+          ></span>
+          <span>{{ isPublished ? "Published" : "Publish" }}</span>
+        </button>
+
+        <!-- Preview -->
+        <RouterLink :to="`/form/${formId}/preview`">
+          <button
+            title="Preview Form"
+            class="custom-btn flex gap-x-2 p-2 rounded-lg"
+            data-cy="preview_btn"
+          >
+            <IconEyeOpen class="w-6 h-6 sm:mr-1" />
+            <span class="hidden sm:block"> Preview </span>
+          </button>
+        </RouterLink>
+      </div>
     </div>
     <div
       v-if="route.name === 'EditForm'"
@@ -122,14 +202,18 @@ const saveStatus = computed(() => {
       >
         <button
           class="w-[120px] font-medium tracking-wide"
-          :class="{ 'text-sky-500': currentSection === 'Questions' }"
+          :class="{
+            'text-sky-500': settingsStore.formSections.editSection === 'Questions',
+          }"
           @click="setSection('Questions')"
         >
           Questions
         </button>
         <button
           class="w-[120px] font-medium tracking-wide"
-          :class="{ 'text-sky-500': currentSection === 'Responses' }"
+          :class="{
+            'text-sky-500': settingsStore.formSections.editSection === 'Responses',
+          }"
           @click="setSection('Responses')"
         >
           Responses
@@ -137,8 +221,10 @@ const saveStatus = computed(() => {
         <div
           class="absolute bottom-0 flex justify-center w-[120px] transition duration-75"
           :class="{
-            'translate-x-full': currentSection === 'Responses',
-            'translate-x-0': currentSection === 'Questions',
+            'translate-x-full':
+              settingsStore.formSections.editSection === 'Responses',
+            'translate-x-0':
+              settingsStore.formSections.editSection === 'Questions',
           }"
         >
           <div class="w-2/3 h-1.5 bg-sky-500 rounded-t-md"></div>

--- a/src/components/form/FormNavbar.vue
+++ b/src/components/form/FormNavbar.vue
@@ -137,10 +137,7 @@ const saveStatus = computed(() => {
 
       <ThemeToggle class="ml-auto mr-3" />
 
-      <div
-        v-if="route.name === 'EditForm'"
-        class="flex items-center gap-x-2"
-      >
+      <div v-if="route.name === 'EditForm'" class="flex items-center gap-x-2">
         <!-- Share link -->
         <button
           type="button"
@@ -203,7 +200,8 @@ const saveStatus = computed(() => {
         <button
           class="w-[120px] font-medium tracking-wide"
           :class="{
-            'text-sky-500': settingsStore.formSections.editSection === 'Questions',
+            'text-sky-500':
+              settingsStore.formSections.editSection === 'Questions',
           }"
           @click="setSection('Questions')"
         >
@@ -212,7 +210,8 @@ const saveStatus = computed(() => {
         <button
           class="w-[120px] font-medium tracking-wide"
           :class="{
-            'text-sky-500': settingsStore.formSections.editSection === 'Responses',
+            'text-sky-500':
+              settingsStore.formSections.editSection === 'Responses',
           }"
           @click="setSection('Responses')"
         >

--- a/src/components/form/response/IndividualView.vue
+++ b/src/components/form/response/IndividualView.vue
@@ -1,0 +1,119 @@
+<script lang="ts" setup>
+import { ref, computed } from "vue";
+import dayjs from "dayjs";
+import type { Question, ResponseAnswer } from "@/types/pocketbase";
+import { useQuestionStore } from "@/store/questions";
+import { useResponseStore } from "@/store/responses";
+
+const questionStore = useQuestionStore();
+const responseStore = useResponseStore();
+
+const index = ref(0);
+
+const current = computed(() => responseStore.responses[index.value]);
+const total = computed(() => responseStore.responses.length);
+
+const currentAnswers = computed(() => {
+  const map = new Map<string, ResponseAnswer>();
+  if (!current.value) return map;
+  for (const a of responseStore.answersByResponse.get(current.value.id) ?? []) {
+    map.set(a.question, a);
+  }
+  return map;
+});
+
+// Render a stored answer value into something human-readable, mapping choice
+// ids back to their labels.
+function formatAnswer(question: Question, answer?: ResponseAnswer): string {
+  const value = answer?.value;
+  if (value === null || value === undefined || value === "") return "—";
+  if (Array.isArray(value) && value.length === 0) return "—";
+
+  const isChoice = ["single_choice", "multiple_choice", "dropdown"].includes(
+    question.type,
+  );
+
+  if (isChoice) {
+    const choices = question.expand?.question_choices ?? [];
+    const labelFor = (id: string) =>
+      choices.find((c) => c.id === id)?.label ?? id;
+    const ids = Array.isArray(value) ? value : [value];
+    return ids.map((id) => labelFor(String(id))).join(", ");
+  }
+
+  if (question.type === "date" && value) {
+    return dayjs(String(value)).format("MMM D, YYYY");
+  }
+
+  if (question.type === "rating") {
+    return "★".repeat(Number(value)) + ` (${value})`;
+  }
+
+  return String(value);
+}
+
+function plainLabel(html: string): string {
+  const el = document.createElement("div");
+  el.innerHTML = html;
+  return el.textContent?.trim() || "Untitled question";
+}
+
+function prev() {
+  if (index.value > 0) index.value--;
+}
+function next() {
+  if (index.value < total.value - 1) index.value++;
+}
+</script>
+
+<template>
+  <div class="flex flex-col gap-4">
+    <div class="flex items-center justify-between gap-3">
+      <p class="text-sm text-neutral-500 dark:text-neutral-400">
+        <span v-if="current">
+          Submitted
+          {{ dayjs(current.submitted_at).format("MMM D, YYYY · h:mm A") }}
+        </span>
+      </p>
+
+      <div class="flex items-center gap-1">
+        <button
+          type="button"
+          @click="prev"
+          :disabled="index === 0"
+          class="rounded-md border border-gray-300 px-3 py-2 text-neutral-600 enabled:hover:border-sky-400 disabled:opacity-40 dark:border-neutral-600 dark:text-neutral-300"
+        >
+          ‹
+        </button>
+        <span class="w-16 text-center text-sm text-neutral-400">
+          {{ index + 1 }} / {{ total }}
+        </span>
+        <button
+          type="button"
+          @click="next"
+          :disabled="index >= total - 1"
+          class="rounded-md border border-gray-300 px-3 py-2 text-neutral-600 enabled:hover:border-sky-400 disabled:opacity-40 dark:border-neutral-600 dark:text-neutral-300"
+        >
+          ›
+        </button>
+      </div>
+    </div>
+
+    <div
+      class="flex flex-col divide-y divide-gray-100 overflow-hidden rounded-xl border border-gray-200 bg-white dark:divide-neutral-800 dark:border-neutral-700 dark:bg-neutral-900"
+    >
+      <div
+        v-for="question in questionStore.questions"
+        :key="question.id"
+        class="flex flex-col gap-1 p-4"
+      >
+        <p class="text-sm font-medium text-neutral-500 dark:text-neutral-400">
+          {{ plainLabel(question.label) }}
+        </p>
+        <p class="text-neutral-800 dark:text-white">
+          {{ formatAnswer(question, currentAnswers.get(question.id)) }}
+        </p>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/components/form/response/QuestionChart.vue
+++ b/src/components/form/response/QuestionChart.vue
@@ -1,0 +1,166 @@
+<script lang="ts" setup>
+import { computed, ref } from "vue";
+import type { Question, ResponseAnswer } from "@/types/pocketbase";
+import { summarizeQuestion } from "@/utils/responses";
+import { useReveal } from "@/composables/useReveal";
+import BarChart from "./charts/BarChart.vue";
+import ColumnChart from "./charts/ColumnChart.vue";
+import DonutChart from "./charts/DonutChart.vue";
+import CountUp from "./charts/CountUp.vue";
+
+const props = defineProps<{
+  question: Question;
+  answers: ResponseAnswer[];
+  totalResponses: number;
+}>();
+
+const summary = computed(() =>
+  summarizeQuestion(props.question, props.answers, props.totalResponses),
+);
+
+const root = ref<HTMLElement | null>(null);
+const { visible } = useReveal(root);
+
+const TYPE_LABEL: Record<string, string> = {
+  short_text: "Short text",
+  long_text: "Long text",
+  single_choice: "Single choice",
+  multiple_choice: "Multiple choice",
+  dropdown: "Dropdown",
+  linear_scale: "Linear scale",
+  number: "Number",
+  email: "Email",
+  date: "Date",
+  rating: "Rating",
+};
+</script>
+
+<template>
+  <div
+    ref="root"
+    class="rounded-xl border border-gray-200 bg-white p-5 shadow-sm transition-all duration-500 dark:border-neutral-700 dark:bg-neutral-900"
+    :class="visible ? 'translate-y-0 opacity-100' : 'translate-y-4 opacity-0'"
+  >
+    <div class="mb-4 flex items-start justify-between gap-3">
+      <div class="min-w-0">
+        <h3
+          v-html="question.label"
+          class="prose prose-sm truncate font-semibold text-neutral-800 dark:prose-invert dark:text-white"
+        ></h3>
+        <p class="mt-0.5 text-xs text-neutral-400">
+          {{ TYPE_LABEL[question.type] ?? question.type }} ·
+          <CountUp :value="summary.respondents" :play="visible" />
+          of {{ totalResponses }} answered
+        </p>
+      </div>
+      <span
+        class="shrink-0 rounded-full bg-sky-50 px-2.5 py-0.5 text-xs font-medium text-sky-600 dark:bg-sky-500/10 dark:text-sky-400"
+      >
+        {{
+          totalResponses
+            ? Math.round((summary.respondents / totalResponses) * 100)
+            : 0
+        }}%
+      </span>
+    </div>
+
+    <!-- No answers for this question -->
+    <p
+      v-if="summary.respondents === 0"
+      class="py-6 text-center text-sm text-neutral-400"
+    >
+      No answers yet
+    </p>
+
+    <!-- Single-select distribution -->
+    <DonutChart
+      v-else-if="summary.kind === 'donut'"
+      :data="summary.data"
+      :play="visible"
+    />
+
+    <!-- Multi-select distribution -->
+    <BarChart
+      v-else-if="summary.kind === 'bar'"
+      :data="summary.data"
+      :play="visible"
+    />
+
+    <!-- Linear scale / rating -->
+    <div v-else-if="summary.kind === 'scale'" class="flex flex-col gap-4">
+      <div class="flex items-baseline gap-2">
+        <span class="text-3xl font-bold text-sky-500">
+          <CountUp
+            :value="summary.stats?.average ?? 0"
+            :play="visible"
+            :decimals="1"
+          />
+        </span>
+        <span class="text-sm text-neutral-400">
+          average out of {{ summary.stats?.max }}
+        </span>
+      </div>
+      <ColumnChart :data="summary.data" :play="visible" />
+    </div>
+
+    <!-- Number -->
+    <div v-else-if="summary.kind === 'number'" class="flex flex-col gap-4">
+      <div class="grid grid-cols-3 gap-3">
+        <div
+          class="rounded-lg bg-neutral-50 p-3 text-center dark:bg-neutral-800"
+        >
+          <p class="text-lg font-bold text-neutral-800 dark:text-white">
+            <CountUp
+              :value="summary.stats?.average ?? 0"
+              :play="visible"
+              :decimals="1"
+            />
+          </p>
+          <p class="text-xs text-neutral-400">Average</p>
+        </div>
+        <div
+          class="rounded-lg bg-neutral-50 p-3 text-center dark:bg-neutral-800"
+        >
+          <p class="text-lg font-bold text-neutral-800 dark:text-white">
+            <CountUp :value="summary.stats?.min ?? 0" :play="visible" />
+          </p>
+          <p class="text-xs text-neutral-400">Min</p>
+        </div>
+        <div
+          class="rounded-lg bg-neutral-50 p-3 text-center dark:bg-neutral-800"
+        >
+          <p class="text-lg font-bold text-neutral-800 dark:text-white">
+            <CountUp :value="summary.stats?.max ?? 0" :play="visible" />
+          </p>
+          <p class="text-xs text-neutral-400">Max</p>
+        </div>
+      </div>
+      <ColumnChart :data="summary.data" :play="visible" />
+    </div>
+
+    <!-- Date -->
+    <ColumnChart
+      v-else-if="summary.kind === 'date'"
+      :data="summary.data"
+      :play="visible"
+    />
+
+    <!-- Text / email — list answers -->
+    <ul
+      v-else-if="summary.kind === 'text'"
+      class="flex max-h-64 flex-col gap-2 overflow-y-auto pr-1"
+    >
+      <li
+        v-for="(value, i) in summary.values"
+        :key="i"
+        class="rounded-lg bg-neutral-50 px-3 py-2 text-sm text-neutral-700 dark:bg-neutral-800 dark:text-neutral-200"
+      >
+        {{ value }}
+      </li>
+    </ul>
+
+    <p v-else class="py-6 text-center text-sm text-neutral-400">
+      No data to chart
+    </p>
+  </div>
+</template>

--- a/src/components/form/response/QuestionView.vue
+++ b/src/components/form/response/QuestionView.vue
@@ -1,0 +1,77 @@
+<script lang="ts" setup>
+import { ref, computed } from "vue";
+import { useQuestionStore } from "@/store/questions";
+import { useResponseStore } from "@/store/responses";
+import QuestionChart from "./QuestionChart.vue";
+
+const questionStore = useQuestionStore();
+const responseStore = useResponseStore();
+
+const index = ref(0);
+
+const current = computed(() => questionStore.questions[index.value]);
+const total = computed(() => questionStore.questions.length);
+
+// Plain-text question label for the <select>, which can't render HTML.
+function plainLabel(html: string): string {
+  const el = document.createElement("div");
+  el.innerHTML = html;
+  return el.textContent?.trim() || "Untitled question";
+}
+
+function prev() {
+  if (index.value > 0) index.value--;
+}
+function next() {
+  if (index.value < total.value - 1) index.value++;
+}
+</script>
+
+<template>
+  <div class="flex flex-col gap-4">
+    <div class="flex items-center gap-3">
+      <select
+        v-model="index"
+        class="flex-grow rounded-md border border-gray-300 bg-white px-3 py-2 outline-none focus:border-sky-500 dark:border-neutral-600 dark:bg-neutral-800 dark:text-white"
+      >
+        <option
+          v-for="(question, i) in questionStore.questions"
+          :key="question.id"
+          :value="i"
+        >
+          {{ i + 1 }}. {{ plainLabel(question.label) }}
+        </option>
+      </select>
+
+      <div class="flex items-center gap-1">
+        <button
+          type="button"
+          @click="prev"
+          :disabled="index === 0"
+          class="rounded-md border border-gray-300 px-3 py-2 text-neutral-600 enabled:hover:border-sky-400 disabled:opacity-40 dark:border-neutral-600 dark:text-neutral-300"
+        >
+          ‹
+        </button>
+        <span class="w-14 text-center text-sm text-neutral-400">
+          {{ index + 1 }} / {{ total }}
+        </span>
+        <button
+          type="button"
+          @click="next"
+          :disabled="index >= total - 1"
+          class="rounded-md border border-gray-300 px-3 py-2 text-neutral-600 enabled:hover:border-sky-400 disabled:opacity-40 dark:border-neutral-600 dark:text-neutral-300"
+        >
+          ›
+        </button>
+      </div>
+    </div>
+
+    <QuestionChart
+      v-if="current"
+      :key="current.id"
+      :question="current"
+      :answers="responseStore.answersByQuestion.get(current.id) ?? []"
+      :total-responses="responseStore.totalResponses"
+    />
+  </div>
+</template>

--- a/src/components/form/response/Response.vue
+++ b/src/components/form/response/Response.vue
@@ -1,9 +1,67 @@
 <script lang="ts" setup>
+import { computed, onMounted, watch } from "vue";
+import { useRoute } from "vue-router";
+import { useResponseStore } from "@/store/responses";
+import { useQuestionStore } from "@/store/questions";
+import { useSettingsStore } from "@/store/settings";
+
 import ResponseHeading from "@/components/form/response/ResponseHeading.vue";
+import SummaryView from "@/components/form/response/SummaryView.vue";
+import QuestionView from "@/components/form/response/QuestionView.vue";
+import IndividualView from "@/components/form/response/IndividualView.vue";
+import Loader from "@/components/anim/Loader.vue";
+
+const route = useRoute();
+const responseStore = useResponseStore();
+const questionStore = useQuestionStore();
+const settingsStore = useSettingsStore();
+
+const section = computed(() => settingsStore.formSections.responseSection);
+
+async function load(formId: string) {
+  if (!questionStore.questions.length) {
+    await questionStore.fetchQuestions(formId);
+  }
+  await responseStore.fetchResponses(formId);
+}
+
+onMounted(() => load(route.params.formId as string));
+
+watch(
+  () => route.params.formId,
+  (id) => id && load(id as string),
+);
 </script>
 
 <template>
-  <div>
+  <div class="flex flex-col gap-6 pb-10">
     <ResponseHeading />
+
+    <div
+      v-if="responseStore.loading"
+      class="flex justify-center py-20 text-sky-500"
+    >
+      <Loader class="h-8 w-8" />
+    </div>
+
+    <template v-else>
+      <div
+        v-if="responseStore.totalResponses === 0"
+        class="flex flex-col items-center justify-center gap-2 rounded-xl border border-dashed border-gray-300 py-20 text-center dark:border-neutral-700"
+      >
+        <p class="text-lg font-medium text-neutral-600 dark:text-neutral-300">
+          No responses yet
+        </p>
+        <p class="text-sm text-neutral-400">
+          Share your form to start collecting responses.
+        </p>
+      </div>
+
+      <template v-else>
+        <SummaryView v-if="section === 'Summary'" />
+        <QuestionView v-else-if="section === 'Question'" />
+        <IndividualView v-else-if="section === 'Individual'" />
+      </template>
+    </template>
   </div>
 </template>

--- a/src/components/form/response/ResponseHeading.vue
+++ b/src/components/form/response/ResponseHeading.vue
@@ -1,37 +1,37 @@
 <script lang="ts" setup>
-import { ref } from "vue";
 import { useSettingsStore } from "@/store/settings";
-import XToggle from "@/components/inputs/Toggle.vue";
+import { useResponseStore } from "@/store/responses";
+import CountUp from "@/components/form/response/charts/CountUp.vue";
 
 const settingsStore = useSettingsStore();
+const responseStore = useResponseStore();
 
-const acceptingResponse = ref(true);
-const responseCategory = ref(["Summary", "Question", "Individual"]);
+const responseCategory = ["Summary", "Question", "Individual"];
+
 function setSection(category: string) {
   settingsStore.formSections.responseSection = category;
 }
 </script>
 
 <template>
-  <div class="rounded-xl overflow-hidden">
+  <div class="overflow-hidden rounded-xl">
     <div
-      class="w-full bg-neutral-100 dark:bg-neutral-900 flex items-center justify-between p-6"
+      class="flex w-full items-center justify-between bg-neutral-100 p-6 dark:bg-neutral-900"
     >
-      <h1 class="text-3xl dark:text-white font-semibold">0 Response</h1>
-      <XToggle
-        label="Accepting Responses"
-        id="accepting-responses"
-        v-model="acceptingResponse"
-      />
+      <h1 class="text-3xl font-semibold dark:text-white">
+        <CountUp :value="responseStore.totalResponses" />
+        {{ responseStore.totalResponses === 1 ? "Response" : "Responses" }}
+      </h1>
     </div>
     <div
-      class="relative flex py-3 bg-sky-100 dark:bg-neutral-700 border-t border-sky-200 dark:border-sky-500"
+      class="relative flex border-t border-sky-200 bg-sky-100 py-3 dark:border-sky-500 dark:bg-neutral-700"
     >
       <div
-        class="flex items-end h-full text-neutral-600 dark:text-white mx-auto"
+        class="mx-auto flex h-full items-end text-neutral-600 dark:text-white"
       >
         <button
           v-for="category in responseCategory"
+          :key="category"
           class="w-[120px] font-medium tracking-wide"
           :class="{
             'text-sky-500':
@@ -42,7 +42,7 @@ function setSection(category: string) {
           {{ category }}
         </button>
         <div
-          class="absolute bottom-0 flex justify-center w-[120px] transition duration-75"
+          class="absolute bottom-0 flex w-[120px] justify-center transition duration-75"
           :class="{
             'translate-x-0':
               settingsStore.formSections.responseSection === 'Summary',
@@ -52,7 +52,7 @@ function setSection(category: string) {
               settingsStore.formSections.responseSection === 'Individual',
           }"
         >
-          <div class="w-2/3 h-1.5 bg-sky-500 rounded-t-md"></div>
+          <div class="h-1.5 w-2/3 rounded-t-md bg-sky-500"></div>
         </div>
       </div>
     </div>

--- a/src/components/form/response/SummaryView.vue
+++ b/src/components/form/response/SummaryView.vue
@@ -1,0 +1,74 @@
+<script lang="ts" setup>
+import { computed } from "vue";
+import dayjs from "dayjs";
+import { useQuestionStore } from "@/store/questions";
+import { useResponseStore } from "@/store/responses";
+import QuestionChart from "./QuestionChart.vue";
+import CountUp from "./charts/CountUp.vue";
+
+const questionStore = useQuestionStore();
+const responseStore = useResponseStore();
+
+const lastResponse = computed(() =>
+  responseStore.lastResponseAt
+    ? dayjs(responseStore.lastResponseAt).format("MMM D, YYYY")
+    : "—",
+);
+
+const answeredRate = computed(() => {
+  const total = responseStore.totalResponses * questionStore.questions.length;
+  if (!total) return 0;
+  return Math.round((responseStore.answers.length / total) * 100);
+});
+</script>
+
+<template>
+  <div class="flex flex-col gap-6">
+    <!-- Overview stats -->
+    <div class="grid grid-cols-2 gap-4 sm:grid-cols-4">
+      <div
+        class="rounded-xl border border-gray-200 bg-white p-5 dark:border-neutral-700 dark:bg-neutral-900"
+      >
+        <p class="text-3xl font-bold text-sky-500">
+          <CountUp :value="responseStore.totalResponses" />
+        </p>
+        <p class="mt-1 text-sm text-neutral-400">Responses</p>
+      </div>
+      <div
+        class="rounded-xl border border-gray-200 bg-white p-5 dark:border-neutral-700 dark:bg-neutral-900"
+      >
+        <p class="text-3xl font-bold text-neutral-800 dark:text-white">
+          <CountUp :value="questionStore.questions.length" />
+        </p>
+        <p class="mt-1 text-sm text-neutral-400">Questions</p>
+      </div>
+      <div
+        class="rounded-xl border border-gray-200 bg-white p-5 dark:border-neutral-700 dark:bg-neutral-900"
+      >
+        <p class="text-3xl font-bold text-neutral-800 dark:text-white">
+          <CountUp :value="answeredRate" suffix="%" />
+        </p>
+        <p class="mt-1 text-sm text-neutral-400">Answered</p>
+      </div>
+      <div
+        class="rounded-xl border border-gray-200 bg-white p-5 dark:border-neutral-700 dark:bg-neutral-900"
+      >
+        <p class="text-lg font-bold text-neutral-800 dark:text-white">
+          {{ lastResponse }}
+        </p>
+        <p class="mt-1 text-sm text-neutral-400">Last response</p>
+      </div>
+    </div>
+
+    <!-- Per-question charts -->
+    <div class="grid grid-cols-1 gap-5 lg:grid-cols-2">
+      <QuestionChart
+        v-for="question in questionStore.questions"
+        :key="question.id"
+        :question="question"
+        :answers="responseStore.answersByQuestion.get(question.id) ?? []"
+        :total-responses="responseStore.totalResponses"
+      />
+    </div>
+  </div>
+</template>

--- a/src/components/form/response/charts/BarChart.vue
+++ b/src/components/form/response/charts/BarChart.vue
@@ -20,7 +20,9 @@ const FILL = "linear-gradient(90deg, #38bdf8 0%, #0284c7 100%)";
         <span class="truncate pr-2 text-neutral-700 dark:text-neutral-200">
           {{ d.label }}
         </span>
-        <span class="shrink-0 tabular-nums text-neutral-500 dark:text-neutral-400">
+        <span
+          class="shrink-0 tabular-nums text-neutral-500 dark:text-neutral-400"
+        >
           <CountUp :value="d.count" :play="play" /> · {{ d.percent }}%
         </span>
       </div>

--- a/src/components/form/response/charts/BarChart.vue
+++ b/src/components/form/response/charts/BarChart.vue
@@ -1,0 +1,41 @@
+<script lang="ts" setup>
+import type { ChartDatum } from "@/utils/responses";
+import CountUp from "./CountUp.vue";
+
+withDefaults(
+  defineProps<{
+    data: ChartDatum[];
+    play?: boolean;
+  }>(),
+  { play: true },
+);
+
+const FILL = "linear-gradient(90deg, #38bdf8 0%, #0284c7 100%)";
+</script>
+
+<template>
+  <div class="flex flex-col gap-3.5">
+    <div v-for="(d, i) in data" :key="d.key" class="flex flex-col gap-1.5">
+      <div class="flex items-center justify-between text-sm">
+        <span class="truncate pr-2 text-neutral-700 dark:text-neutral-200">
+          {{ d.label }}
+        </span>
+        <span class="shrink-0 tabular-nums text-neutral-500 dark:text-neutral-400">
+          <CountUp :value="d.count" :play="play" /> · {{ d.percent }}%
+        </span>
+      </div>
+      <div
+        class="h-3 w-full overflow-hidden rounded-full bg-neutral-200 dark:bg-neutral-800"
+      >
+        <div
+          class="h-full rounded-full transition-[width] duration-700 ease-out"
+          :style="{
+            width: play ? d.percent + '%' : '0%',
+            transitionDelay: i * 80 + 'ms',
+            background: FILL,
+          }"
+        ></div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/components/form/response/charts/ColumnChart.vue
+++ b/src/components/form/response/charts/ColumnChart.vue
@@ -1,0 +1,52 @@
+<script lang="ts" setup>
+import { computed } from "vue";
+import type { ChartDatum } from "@/utils/responses";
+import CountUp from "./CountUp.vue";
+
+const props = withDefaults(
+  defineProps<{
+    data: ChartDatum[];
+    play?: boolean;
+  }>(),
+  { play: true },
+);
+
+const maxCount = computed(() =>
+  Math.max(1, ...props.data.map((d) => d.count)),
+);
+
+const FILL = "linear-gradient(180deg, #38bdf8 0%, #0284c7 100%)";
+</script>
+
+<template>
+  <div class="flex h-48 w-full items-end gap-2">
+    <div
+      v-for="(d, i) in data"
+      :key="d.key"
+      class="flex min-w-0 flex-1 flex-col items-center justify-end gap-1.5"
+    >
+      <span
+        class="text-xs font-medium tabular-nums text-neutral-500 dark:text-neutral-400"
+      >
+        <CountUp :value="d.count" :play="play" />
+      </span>
+      <div class="flex w-full justify-center">
+        <div
+          class="w-full max-w-[46px] rounded-t-md transition-[height] duration-700 ease-out"
+          :style="{
+            height:
+              (play ? (d.count / maxCount) * 140 : 0) + 'px',
+            transitionDelay: i * 60 + 'ms',
+            background: FILL,
+          }"
+        ></div>
+      </div>
+      <span
+        class="w-full truncate text-center text-xs text-neutral-600 dark:text-neutral-300"
+        :title="d.label"
+      >
+        {{ d.label }}
+      </span>
+    </div>
+  </div>
+</template>

--- a/src/components/form/response/charts/ColumnChart.vue
+++ b/src/components/form/response/charts/ColumnChart.vue
@@ -11,9 +11,7 @@ const props = withDefaults(
   { play: true },
 );
 
-const maxCount = computed(() =>
-  Math.max(1, ...props.data.map((d) => d.count)),
-);
+const maxCount = computed(() => Math.max(1, ...props.data.map((d) => d.count)));
 
 const FILL = "linear-gradient(180deg, #38bdf8 0%, #0284c7 100%)";
 </script>
@@ -34,8 +32,7 @@ const FILL = "linear-gradient(180deg, #38bdf8 0%, #0284c7 100%)";
         <div
           class="w-full max-w-[46px] rounded-t-md transition-[height] duration-700 ease-out"
           :style="{
-            height:
-              (play ? (d.count / maxCount) * 140 : 0) + 'px',
+            height: (play ? (d.count / maxCount) * 140 : 0) + 'px',
             transitionDelay: i * 60 + 'ms',
             background: FILL,
           }"

--- a/src/components/form/response/charts/CountUp.vue
+++ b/src/components/form/response/charts/CountUp.vue
@@ -1,0 +1,48 @@
+<script lang="ts" setup>
+import { ref, watch, onUnmounted } from "vue";
+
+const props = withDefaults(
+  defineProps<{
+    value: number;
+    play?: boolean;
+    duration?: number;
+    decimals?: number;
+    suffix?: string;
+  }>(),
+  { play: true, duration: 900, decimals: 0, suffix: "" },
+);
+
+const display = ref(0);
+let raf = 0;
+
+function animate() {
+  cancelAnimationFrame(raf);
+  const end = props.value;
+  const start = performance.now();
+
+  const step = (now: number) => {
+    const t = Math.min((now - start) / props.duration, 1);
+    const eased = 1 - Math.pow(1 - t, 3); // easeOutCubic
+    display.value = end * eased;
+    if (t < 1) raf = requestAnimationFrame(step);
+    else display.value = end;
+  };
+
+  raf = requestAnimationFrame(step);
+}
+
+watch(
+  () => [props.play, props.value],
+  () => {
+    if (props.play) animate();
+    else display.value = 0;
+  },
+  { immediate: true },
+);
+
+onUnmounted(() => cancelAnimationFrame(raf));
+</script>
+
+<template>
+  <span>{{ display.toFixed(decimals) }}{{ suffix }}</span>
+</template>

--- a/src/components/form/response/charts/DonutChart.vue
+++ b/src/components/form/response/charts/DonutChart.vue
@@ -1,0 +1,106 @@
+<script lang="ts" setup>
+import { computed } from "vue";
+import type { ChartDatum } from "@/utils/responses";
+import CountUp from "./CountUp.vue";
+
+const props = withDefaults(
+  defineProps<{
+    data: ChartDatum[];
+    play?: boolean;
+  }>(),
+  { play: true },
+);
+
+const COLORS = [
+  "#0ea5e9",
+  "#6366f1",
+  "#22c55e",
+  "#f59e0b",
+  "#ec4899",
+  "#14b8a6",
+  "#a855f7",
+  "#ef4444",
+  "#84cc16",
+  "#f97316",
+];
+
+const RADIUS = 60;
+const CIRC = 2 * Math.PI * RADIUS;
+
+const total = computed(() => props.data.reduce((s, d) => s + d.count, 0));
+
+const segments = computed(() => {
+  let offset = 0;
+  return props.data.map((d, i) => {
+    const fraction = total.value ? d.count / total.value : 0;
+    const length = fraction * CIRC;
+    const seg = {
+      ...d,
+      color: COLORS[i % COLORS.length],
+      dashArray: `${length} ${CIRC - length}`,
+      dashOffset: -offset,
+    };
+    offset += length;
+    return seg;
+  });
+});
+</script>
+
+<template>
+  <div class="flex flex-col items-center gap-6 sm:flex-row">
+    <div class="relative shrink-0">
+      <svg width="160" height="160" viewBox="0 0 160 160" class="-rotate-90">
+        <circle
+          cx="80"
+          cy="80"
+          :r="RADIUS"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="18"
+          class="text-neutral-200 dark:text-neutral-800"
+        />
+        <circle
+          v-for="(s, i) in segments"
+          :key="s.key"
+          cx="80"
+          cy="80"
+          :r="RADIUS"
+          fill="none"
+          :stroke="s.color"
+          stroke-width="18"
+          :stroke-dasharray="play ? s.dashArray : `0 ${CIRC}`"
+          :stroke-dashoffset="s.dashOffset"
+          class="transition-[stroke-dasharray] duration-700 ease-out"
+          :style="{ transitionDelay: i * 120 + 'ms' }"
+        />
+      </svg>
+      <div class="absolute inset-0 flex flex-col items-center justify-center">
+        <span class="text-2xl font-bold text-neutral-800 dark:text-white">
+          <CountUp :value="total" :play="play" />
+        </span>
+        <span class="text-xs text-neutral-500">answers</span>
+      </div>
+    </div>
+
+    <ul class="flex w-full flex-col gap-2">
+      <li
+        v-for="s in segments"
+        :key="s.key"
+        class="flex items-center gap-2 text-sm"
+      >
+        <span
+          class="h-3 w-3 shrink-0 rounded-full"
+          :style="{ backgroundColor: s.color }"
+        ></span>
+        <span class="truncate text-neutral-700 dark:text-neutral-200">
+          {{ s.label }}
+        </span>
+        <span
+          class="ml-auto shrink-0 tabular-nums text-neutral-500 dark:text-neutral-400"
+        >
+          {{ s.count }} · {{ s.percent }}%
+        </span>
+      </li>
+    </ul>
+  </div>
+</template>

--- a/src/composables/useReveal.ts
+++ b/src/composables/useReveal.ts
@@ -1,0 +1,29 @@
+import { ref, type Ref } from "vue";
+import { useIntersectionObserver } from "@vueuse/core";
+
+/**
+ * Flip `visible` to true the first time `target` scrolls into view. Used to
+ * trigger chart entrance/draw animations only once the chart is on screen.
+ */
+export function useReveal(
+  target: Ref<HTMLElement | null>,
+  options: { once?: boolean; threshold?: number } = {},
+) {
+  const { once = true, threshold = 0.2 } = options;
+  const visible = ref(false);
+
+  const { stop } = useIntersectionObserver(
+    target,
+    ([entry]) => {
+      if (entry?.isIntersecting) {
+        visible.value = true;
+        if (once) stop();
+      } else if (!once) {
+        visible.value = false;
+      }
+    },
+    { threshold },
+  );
+
+  return { visible };
+}

--- a/src/pages/form/edit.vue
+++ b/src/pages/form/edit.vue
@@ -1,14 +1,21 @@
 <script lang="ts" setup>
+import { computed } from "vue";
 import { useRoute } from "vue-router";
+import { useSettingsStore } from "@/store/settings";
 import FormQuestionList from "@/components/form/question/FormQuestionList.vue";
+import Response from "@/components/form/response/Response.vue";
 
 const route = useRoute();
+const settingsStore = useSettingsStore();
+
+const section = computed(() => settingsStore.formSections.editSection);
 </script>
 
 <template>
   <div class="px-5 pt-5">
-    <div class="w-full max-w-[1000px] mx-auto">
-      <FormQuestionList :form-id="(route.params.formId as string)" />
+    <div class="mx-auto w-full max-w-[1000px]">
+      <Response v-if="section === 'Responses'" />
+      <FormQuestionList v-else :form-id="(route.params.formId as string)" />
     </div>
   </div>
 </template>

--- a/src/pages/form/edit.vue
+++ b/src/pages/form/edit.vue
@@ -15,7 +15,7 @@ const section = computed(() => settingsStore.formSections.editSection);
   <div class="px-5 pt-5">
     <div class="mx-auto w-full max-w-[1000px]">
       <Response v-if="section === 'Responses'" />
-      <FormQuestionList v-else :form-id="(route.params.formId as string)" />
+      <FormQuestionList v-else :form-id="route.params.formId as string" />
     </div>
   </div>
 </template>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -98,6 +98,10 @@ const router = createRouter({
           path: "view",
           name: "ViewForm",
           component: () => import("@/pages/form/view.vue"),
+          // Public so shared links can collect responses without a login.
+          meta: {
+            authRequired: false,
+          },
         },
         {
           path: "preview",

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -108,8 +108,8 @@ const router = createRouter({
           name: "PreviewForm",
           component: () => import("@/pages/form/preview.vue"),
           meta: {
-            authRequired: true
-          }
+            authRequired: true,
+          },
         },
         {
           path: "success",

--- a/src/store/forms.ts
+++ b/src/store/forms.ts
@@ -77,6 +77,37 @@ export const useFormStore = defineStore("forms", {
       await pb.collection("forms").update(form.id, form);
       this.fetchForms();
     },
+
+    // Load a single form into the store when navigating straight to an editor
+    // route without going through the dashboard list first.
+    async fetchForm(formId: string) {
+      const form = await pb.collection("forms").getOne<Form>(formId);
+      const index = this.forms.findIndex((f) => f.id === formId);
+      if (index === -1) this.forms.push(form);
+      else this.forms[index] = form;
+      return form;
+    },
+
+    async setStatus(formId: string, status: Form["status"]) {
+      this.saveStatus = "saving";
+      try {
+        const updated = await pb
+          .collection("forms")
+          .update<Form>(formId, { status });
+        const index = this.forms.findIndex((f) => f.id === formId);
+        if (index === -1) this.forms.push(updated);
+        else this.forms[index] = updated;
+        this.saveStatus = "saved";
+        setTimeout(() => {
+          if (this.saveStatus === "saved") this.saveStatus = "idle";
+        }, 2000);
+      } catch {
+        this.saveStatus = "error";
+        setTimeout(() => {
+          if (this.saveStatus === "error") this.saveStatus = "idle";
+        }, 3000);
+      }
+    },
     async deleteForm(formId: string) {
       await pb.collection("forms").delete(formId);
       this.fetchForms();

--- a/src/store/responses.ts
+++ b/src/store/responses.ts
@@ -1,0 +1,74 @@
+import { defineStore } from "pinia";
+import pb from "@/db/pocketBase";
+import type { Response, ResponseAnswer } from "@/types/pocketbase";
+
+export const useResponseStore = defineStore("responses", {
+  state: () => ({
+    responses: [] as Response[],
+    answers: [] as ResponseAnswer[],
+    loading: false,
+    loaded: false,
+  }),
+
+  getters: {
+    totalResponses(): number {
+      return this.responses.length;
+    },
+
+    // question.id → answers for that question
+    answersByQuestion(): Map<string, ResponseAnswer[]> {
+      const map = new Map<string, ResponseAnswer[]>();
+      for (const answer of this.answers) {
+        const group = map.get(answer.question) ?? [];
+        group.push(answer);
+        map.set(answer.question, group);
+      }
+      return map;
+    },
+
+    // response.id → answers for that submission
+    answersByResponse(): Map<string, ResponseAnswer[]> {
+      const map = new Map<string, ResponseAnswer[]>();
+      for (const answer of this.answers) {
+        const group = map.get(answer.response) ?? [];
+        group.push(answer);
+        map.set(answer.response, group);
+      }
+      return map;
+    },
+
+    lastResponseAt(): string | null {
+      return this.responses[0]?.submitted_at || null;
+    },
+  },
+
+  actions: {
+    async fetchResponses(formId: string) {
+      this.loading = true;
+      try {
+        // Only completed submissions count as "responses".
+        this.responses = await pb
+          .collection("responses")
+          .getFullList<Response>({
+            filter: `form="${formId}" && is_complete=true`,
+            sort: "-submitted_at",
+          });
+
+        // Pull the answers via a relation filter so we don't have to enumerate
+        // every response id into the query string.
+        if (this.responses.length) {
+          this.answers = await pb
+            .collection("response_answers")
+            .getFullList<ResponseAnswer>({
+              filter: `response.form="${formId}" && response.is_complete=true`,
+            });
+        } else {
+          this.answers = [];
+        }
+      } finally {
+        this.loading = false;
+        this.loaded = true;
+      }
+    },
+  },
+});

--- a/src/utils/responses.ts
+++ b/src/utils/responses.ts
@@ -1,0 +1,220 @@
+import type { Question, ResponseAnswer } from "@/types/pocketbase";
+
+export interface ChartDatum {
+  key: string;
+  label: string;
+  count: number;
+  percent: number; // 0-100, relative to the number of respondents who answered
+}
+
+export type ChartKind =
+  | "donut" // single-select distribution (parts of a whole)
+  | "bar" // multi-select distribution (horizontal bars)
+  | "scale" // linear_scale / rating distribution (columns) + average
+  | "number" // numeric histogram + min/avg/max
+  | "text" // raw answer list (short/long text, email)
+  | "date" // per-day distribution + raw list
+  | "empty"; // nothing chartable yet
+
+export interface QuestionSummary {
+  kind: ChartKind;
+  data: ChartDatum[];
+  values: string[]; // raw answers for text/date lists
+  respondents: number; // submissions that answered this question
+  totalResponses: number; // total submissions for the form
+  stats?: {
+    average?: number;
+    min?: number;
+    max?: number;
+  };
+}
+
+function isEmpty(value: ResponseAnswer["value"]): boolean {
+  if (value === null || value === undefined) return true;
+  if (Array.isArray(value)) return value.length === 0;
+  return String(value).trim() === "";
+}
+
+function fmt(n: number): string {
+  return Number.isInteger(n) ? String(n) : n.toFixed(1);
+}
+
+// Build a small distribution for numeric answers: one bar per distinct value
+// when there are only a few, otherwise fixed-width histogram bins.
+function histogram(nums: number[], min: number, max: number): ChartDatum[] {
+  const denom = nums.length || 1;
+  const distinct = new Set(nums);
+
+  if (distinct.size <= 8) {
+    const counts = new Map<number, number>();
+    for (const n of nums) counts.set(n, (counts.get(n) ?? 0) + 1);
+    return [...counts.entries()]
+      .sort((a, b) => a[0] - b[0])
+      .map(([value, count]) => ({
+        key: String(value),
+        label: fmt(value),
+        count,
+        percent: Math.round((count / denom) * 100),
+      }));
+  }
+
+  const bins = 8;
+  const span = max - min || 1;
+  const size = span / bins;
+  const counts = new Array(bins).fill(0);
+
+  for (const n of nums) {
+    let idx = Math.floor((n - min) / size);
+    if (idx >= bins) idx = bins - 1;
+    if (idx < 0) idx = 0;
+    counts[idx]++;
+  }
+
+  return counts.map((count, i) => {
+    const lo = min + i * size;
+    const hi = lo + size;
+    return {
+      key: String(i),
+      label: `${fmt(lo)}–${fmt(hi)}`,
+      count,
+      percent: Math.round((count / denom) * 100),
+    };
+  });
+}
+
+/**
+ * Aggregate every answer for a single question into chart-ready data. The shape
+ * returned depends on the question type — see {@link ChartKind}.
+ */
+export function summarizeQuestion(
+  question: Question,
+  answers: ResponseAnswer[],
+  totalResponses: number,
+): QuestionSummary {
+  const nonEmpty = answers.filter((a) => !isEmpty(a.value));
+  const respondents = nonEmpty.length;
+  const base = {
+    data: [] as ChartDatum[],
+    values: [] as string[],
+    respondents,
+    totalResponses,
+  };
+
+  switch (question.type) {
+    case "single_choice":
+    case "multiple_choice":
+    case "dropdown": {
+      const choices = question.expand?.question_choices ?? [];
+      const counts = new Map<string, number>();
+      for (const c of choices) counts.set(c.id, 0);
+
+      for (const a of nonEmpty) {
+        const ids = Array.isArray(a.value) ? a.value : [a.value];
+        for (const raw of ids) {
+          const id = String(raw);
+          if (counts.has(id)) counts.set(id, (counts.get(id) ?? 0) + 1);
+        }
+      }
+
+      const denom = respondents || 1;
+      const data: ChartDatum[] = choices.map((c) => {
+        const count = counts.get(c.id) ?? 0;
+        return {
+          key: c.id,
+          label: c.label,
+          count,
+          percent: Math.round((count / denom) * 100),
+        };
+      });
+
+      return {
+        ...base,
+        kind: question.type === "multiple_choice" ? "bar" : "donut",
+        data,
+      };
+    }
+
+    case "linear_scale":
+    case "rating": {
+      const max = question.type === "rating" ? 5 : 10;
+      const counts = new Array(max + 1).fill(0);
+      let sum = 0;
+      let n = 0;
+
+      for (const a of nonEmpty) {
+        const num = Number(a.value);
+        if (!Number.isFinite(num)) continue;
+        const v = Math.round(num);
+        if (v >= 1 && v <= max) {
+          counts[v]++;
+          sum += v;
+          n++;
+        }
+      }
+
+      const denom = n || 1;
+      const data: ChartDatum[] = [];
+      for (let i = 1; i <= max; i++) {
+        data.push({
+          key: String(i),
+          label: String(i),
+          count: counts[i],
+          percent: Math.round((counts[i] / denom) * 100),
+        });
+      }
+
+      return {
+        ...base,
+        kind: "scale",
+        data,
+        stats: { average: n ? sum / n : 0, max },
+      };
+    }
+
+    case "number": {
+      const nums = nonEmpty.map((a) => Number(a.value)).filter(Number.isFinite);
+      if (!nums.length) return { ...base, kind: "empty" };
+
+      const min = Math.min(...nums);
+      const max = Math.max(...nums);
+      const average = nums.reduce((s, n) => s + n, 0) / nums.length;
+
+      return {
+        ...base,
+        kind: "number",
+        data: histogram(nums, min, max),
+        stats: { average, min, max },
+      };
+    }
+
+    case "date": {
+      const counts = new Map<string, number>();
+      for (const a of nonEmpty) {
+        const day = String(a.value).slice(0, 10);
+        counts.set(day, (counts.get(day) ?? 0) + 1);
+      }
+
+      const denom = respondents || 1;
+      const data = [...counts.entries()]
+        .sort((a, b) => a[0].localeCompare(b[0]))
+        .map(([day, count]) => ({
+          key: day,
+          label: day,
+          count,
+          percent: Math.round((count / denom) * 100),
+        }));
+
+      const values = nonEmpty
+        .map((a) => String(a.value).slice(0, 10))
+        .sort((a, b) => a.localeCompare(b));
+
+      return { ...base, kind: "date", data, values };
+    }
+
+    default: {
+      // short_text, long_text, email
+      const values = nonEmpty.map((a) => String(a.value));
+      return { ...base, kind: "text", values };
+    }
+  }
+}

--- a/tests/responses.spec.ts
+++ b/tests/responses.spec.ts
@@ -138,13 +138,53 @@ function buildChoices(): QuestionChoice[] {
 // Three completed submissions. r-3 deliberately omits a comment so the
 // "answered" rate and per-question respondent counts differ from the total.
 const RESPONSES: Response[] = [
-  { id: "r-1", form: FORM_ID, respondent: "u1", is_complete: true, submitted_at: "2026-06-20T10:00:00Z", ...meta, collectionId: "responses", collectionName: "responses" },
-  { id: "r-2", form: FORM_ID, respondent: "u2", is_complete: true, submitted_at: "2026-06-19T10:00:00Z", ...meta, collectionId: "responses", collectionName: "responses" },
-  { id: "r-3", form: FORM_ID, respondent: "u3", is_complete: true, submitted_at: "2026-06-18T10:00:00Z", ...meta, collectionId: "responses", collectionName: "responses" },
+  {
+    id: "r-1",
+    form: FORM_ID,
+    respondent: "u1",
+    is_complete: true,
+    submitted_at: "2026-06-20T10:00:00Z",
+    ...meta,
+    collectionId: "responses",
+    collectionName: "responses",
+  },
+  {
+    id: "r-2",
+    form: FORM_ID,
+    respondent: "u2",
+    is_complete: true,
+    submitted_at: "2026-06-19T10:00:00Z",
+    ...meta,
+    collectionId: "responses",
+    collectionName: "responses",
+  },
+  {
+    id: "r-3",
+    form: FORM_ID,
+    respondent: "u3",
+    is_complete: true,
+    submitted_at: "2026-06-18T10:00:00Z",
+    ...meta,
+    collectionId: "responses",
+    collectionName: "responses",
+  },
 ];
 
-function answer(id: string, response: string, question: string, value: ResponseAnswer["value"]): ResponseAnswer {
-  return { id, response, question, value, ...meta, collectionId: "response_answers", collectionName: "response_answers" };
+function answer(
+  id: string,
+  response: string,
+  question: string,
+  value: ResponseAnswer["value"],
+): ResponseAnswer {
+  return {
+    id,
+    response,
+    question,
+    value,
+    ...meta,
+    collectionId: "response_answers",
+    collectionName: "response_answers",
+  };
 }
 
 const ANSWERS: ResponseAnswer[] = [
@@ -214,7 +254,9 @@ async function gotoEdit(page: Page, seed: Seed = {}) {
 // heading to render. The tab only appears on the EditForm route.
 async function openResponses(page: Page) {
   await page.getByRole("button", { name: "Responses", exact: true }).click();
-  await expect(page.getByRole("heading", { name: /Responses?$/ })).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: /Responses?$/ }),
+  ).toBeVisible();
 }
 
 test.beforeEach(async ({ page }) => {
@@ -319,6 +361,8 @@ test.describe("Publish & share controls", () => {
 
     // Copying the link gives transient "Copied!" feedback.
     await page.locator('[data-cy="share_btn"]').click();
-    await expect(page.locator('[data-cy="share_btn"]')).toContainText("Copied!");
+    await expect(page.locator('[data-cy="share_btn"]')).toContainText(
+      "Copied!",
+    );
   });
 });

--- a/tests/responses.spec.ts
+++ b/tests/responses.spec.ts
@@ -1,0 +1,324 @@
+import { test, expect, type Page } from "@playwright/test";
+import type {
+  Question,
+  QuestionChoice,
+  QuestionType,
+  Response,
+  ResponseAnswer,
+} from "../src/types/pocketbase";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Form-responses dashboard E2E
+//
+// Exercises the new responses analytics views (src/components/form/response/*)
+// and the aggregation logic in summarizeQuestion() (src/utils/responses.ts)
+// end-to-end through the form editor's "Responses" section, plus the publish /
+// share controls added to FormNavbar.vue.
+//
+// Like validation.spec.ts, every PocketBase read is mocked and a structurally
+// valid (but fake) session is injected, so the auth-guarded /form/:id/edit route
+// renders without provisioning real records. No network writes, no account, no
+// cleanup — fully deterministic and CI-safe.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const FORM_ID = "e2e-responses-form";
+
+// The editor reads `pb.authStore.isValid`, which decodes the JWT in
+// localStorage["pocketbase_auth"] and checks its `exp`. A token with a
+// far-future exp passes the guard without any real auth request.
+function injectFakeAuth(page: Page) {
+  return page.addInitScript(() => {
+    const payload = {
+      exp: 9999999999, // year 2286 — never "expired"
+      id: "e2e-user",
+      type: "auth",
+      collectionId: "_pb_users_auth_",
+    };
+    const token = `x.${btoa(JSON.stringify(payload))}.y`;
+    localStorage.setItem(
+      "pocketbase_auth",
+      JSON.stringify({
+        token,
+        record: {
+          id: "e2e-user",
+          email: "e2e@formjam.test",
+          collectionName: "users",
+        },
+      }),
+    );
+  });
+}
+
+// PocketBase list-response envelope (getList / getFullList both expect it).
+function listBody(items: unknown[]) {
+  return JSON.stringify({
+    page: 1,
+    perPage: 500,
+    totalItems: items.length,
+    totalPages: 1,
+    items,
+  });
+}
+
+const meta = {
+  created: "",
+  updated: "",
+};
+
+function buildForm(status: "draft" | "published" | "closed") {
+  return {
+    id: FORM_ID,
+    title: "Responses Test Form",
+    description: "",
+    status,
+    view_mode: "list",
+    starred: false,
+    slug: "e2e-responses",
+    settings: {},
+    user: "e2e-user",
+    ...meta,
+    collectionId: "forms",
+    collectionName: "forms",
+  };
+}
+
+type QuestionSeed = {
+  id: string;
+  label: string;
+  type: QuestionType;
+  choices?: { id: string; label: string }[];
+};
+
+// Three questions covering the main chart kinds: a single-choice (donut), a
+// short-text (raw list) and a rating (scale + average).
+const QUESTIONS: QuestionSeed[] = [
+  {
+    id: "q-color",
+    label: "Favorite color",
+    type: "single_choice",
+    choices: [
+      { id: "c-red", label: "Red" },
+      { id: "c-blue", label: "Blue" },
+    ],
+  },
+  { id: "q-comment", label: "Any comments?", type: "short_text" },
+  { id: "q-rating", label: "Rate us", type: "rating" },
+];
+
+function buildQuestions(): Question[] {
+  return QUESTIONS.map((seed, i) => ({
+    id: seed.id,
+    label: seed.label,
+    description: "",
+    type: seed.type,
+    order: i + 1,
+    required: false,
+    settings: {},
+    form: FORM_ID,
+    ...meta,
+    collectionId: "questions",
+    collectionName: "questions",
+  }));
+}
+
+function buildChoices(): QuestionChoice[] {
+  return QUESTIONS.flatMap((seed) =>
+    (seed.choices ?? []).map((c, order) => ({
+      id: c.id,
+      label: c.label,
+      order: order + 1,
+      question: seed.id,
+      ...meta,
+      collectionId: "question_choices",
+      collectionName: "question_choices",
+    })),
+  );
+}
+
+// Three completed submissions. r-3 deliberately omits a comment so the
+// "answered" rate and per-question respondent counts differ from the total.
+const RESPONSES: Response[] = [
+  { id: "r-1", form: FORM_ID, respondent: "u1", is_complete: true, submitted_at: "2026-06-20T10:00:00Z", ...meta, collectionId: "responses", collectionName: "responses" },
+  { id: "r-2", form: FORM_ID, respondent: "u2", is_complete: true, submitted_at: "2026-06-19T10:00:00Z", ...meta, collectionId: "responses", collectionName: "responses" },
+  { id: "r-3", form: FORM_ID, respondent: "u3", is_complete: true, submitted_at: "2026-06-18T10:00:00Z", ...meta, collectionId: "responses", collectionName: "responses" },
+];
+
+function answer(id: string, response: string, question: string, value: ResponseAnswer["value"]): ResponseAnswer {
+  return { id, response, question, value, ...meta, collectionId: "response_answers", collectionName: "response_answers" };
+}
+
+const ANSWERS: ResponseAnswer[] = [
+  answer("a1", "r-1", "q-color", "c-red"),
+  answer("a2", "r-1", "q-comment", "Loved it"),
+  answer("a3", "r-1", "q-rating", 5),
+  answer("a4", "r-2", "q-color", "c-blue"),
+  answer("a5", "r-2", "q-comment", "Pretty good"),
+  answer("a6", "r-2", "q-rating", 4),
+  answer("a7", "r-3", "q-color", "c-red"),
+  answer("a8", "r-3", "q-rating", 3),
+  // r-3 has no comment answer.
+];
+
+type Seed = {
+  status?: "draft" | "published" | "closed";
+  responses?: Response[];
+  answers?: ResponseAnswer[];
+};
+
+// Mocks every collection the editor + responses views read, then navigates to
+// the edit route. Returns the live form status so PATCH-aware tests can flip it.
+async function gotoEdit(page: Page, seed: Seed = {}) {
+  let status = seed.status ?? "published";
+  const responses = seed.responses ?? RESPONSES;
+  const answers = seed.answers ?? ANSWERS;
+
+  const json = (body: string) =>
+    ({ status: 200, contentType: "application/json", body }) as const;
+
+  // forms — getOne (FormNavbar.fetchForm) + PATCH (publish toggle) + getList.
+  await page.route(/\/api\/collections\/forms\/records/, (route) => {
+    const req = route.request();
+    if (req.method() === "PATCH") {
+      const body = JSON.parse(req.postData() || "{}");
+      if (body.status) status = body.status;
+      return route.fulfill(json(JSON.stringify(buildForm(status))));
+    }
+    // getOne hits /records/<id>; getList hits /records?<query>.
+    if (/\/records\/[^/?]+/.test(req.url())) {
+      return route.fulfill(json(JSON.stringify(buildForm(status))));
+    }
+    return route.fulfill(json(listBody([buildForm(status)])));
+  });
+
+  await page.route(/\/api\/collections\/questions\/records/, (route) =>
+    route.fulfill(json(listBody(buildQuestions()))),
+  );
+
+  await page.route(/\/api\/collections\/question_choices\/records/, (route) =>
+    route.fulfill(json(listBody(buildChoices()))),
+  );
+
+  await page.route(/\/api\/collections\/responses\/records/, (route) =>
+    route.fulfill(json(listBody(responses))),
+  );
+
+  await page.route(/\/api\/collections\/response_answers\/records/, (route) =>
+    route.fulfill(json(listBody(answers))),
+  );
+
+  await page.goto(`/form/${FORM_ID}/edit`);
+  await expect(page).toHaveURL(/\/edit/);
+}
+
+// Switches the editor to the Responses section (a navbar tab) and waits for the
+// heading to render. The tab only appears on the EditForm route.
+async function openResponses(page: Page) {
+  await page.getByRole("button", { name: "Responses", exact: true }).click();
+  await expect(page.getByRole("heading", { name: /Responses?$/ })).toBeVisible();
+}
+
+test.beforeEach(async ({ page }) => {
+  await injectFakeAuth(page);
+});
+
+test.describe("Responses dashboard", () => {
+  test("summary view aggregates answers into charts", async ({ page }) => {
+    await gotoEdit(page);
+    await openResponses(page);
+
+    // Heading reflects the (animated) response count — settles on the value.
+    await expect(
+      page.getByRole("heading", { name: /Responses$/ }),
+    ).toContainText("3");
+
+    // Single-choice question → donut legend with per-choice counts/percent.
+    await expect(page.getByText("Favorite color")).toBeVisible();
+    await expect(page.getByText("Red", { exact: true })).toBeVisible();
+    await expect(page.getByText("2 · 67%")).toBeVisible();
+    await expect(page.getByText("Blue", { exact: true })).toBeVisible();
+    await expect(page.getByText("1 · 33%")).toBeVisible();
+
+    // Short-text question → raw answer list.
+    await expect(page.getByText("Loved it")).toBeVisible();
+    await expect(page.getByText("Pretty good")).toBeVisible();
+
+    // Rating question → average (5 + 4 + 3) / 3 = 4.0 out of 5.
+    await expect(page.getByText("average out of 5")).toBeVisible();
+  });
+
+  test("question view pages through one question at a time", async ({
+    page,
+  }) => {
+    await gotoEdit(page);
+    await openResponses(page);
+    await page.getByRole("button", { name: "Question", exact: true }).click();
+
+    // Defaults to the first question.
+    await expect(page.locator("select")).toBeVisible();
+    await expect(page.getByText("1 / 3")).toBeVisible();
+
+    // Jump to the short-text question and confirm its answers render.
+    await page.locator("select").selectOption({ label: "2. Any comments?" });
+    await expect(page.getByText("Loved it")).toBeVisible();
+    await expect(page.getByText("Pretty good")).toBeVisible();
+  });
+
+  test("individual view shows a single submission's answers", async ({
+    page,
+  }) => {
+    await gotoEdit(page);
+    await openResponses(page);
+    await page.getByRole("button", { name: "Individual", exact: true }).click();
+
+    // Newest submission first (r-1): choice mapped to its label, rating as stars.
+    await expect(page.getByText("1 / 3")).toBeVisible();
+    await expect(page.getByText("Red", { exact: true })).toBeVisible();
+    await expect(page.getByText("Loved it")).toBeVisible();
+    await expect(page.getByText("★★★★★ (5)")).toBeVisible();
+
+    // Step to the next submission (r-2).
+    await page.getByRole("button", { name: "›" }).click();
+    await expect(page.getByText("2 / 3")).toBeVisible();
+    await expect(page.getByText("Blue", { exact: true })).toBeVisible();
+    await expect(page.getByText("Pretty good")).toBeVisible();
+    await expect(page.getByText("★★★★ (4)")).toBeVisible();
+  });
+
+  test("shows an empty state when there are no responses", async ({ page }) => {
+    await gotoEdit(page, { responses: [], answers: [] });
+    await openResponses(page);
+
+    await expect(page.getByText("No responses yet")).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: /^0 Responses$/ }),
+    ).toBeVisible();
+  });
+});
+
+test.describe("Publish & share controls", () => {
+  test("share is disabled until the form is published", async ({ page }) => {
+    await gotoEdit(page, { status: "draft" });
+
+    await expect(page.locator('[data-cy="share_btn"]')).toBeDisabled();
+    await expect(page.locator('[data-cy="publish_btn"]')).toContainText(
+      "Publish",
+    );
+  });
+
+  test("publishing enables the share link", async ({ page, context }) => {
+    await context.grantPermissions(["clipboard-write"]);
+    await gotoEdit(page, { status: "draft" });
+
+    await page.locator('[data-cy="publish_btn"]').click();
+
+    // Toggle reflects the new status and the share button unlocks.
+    await expect(page.locator('[data-cy="publish_btn"]')).toContainText(
+      "Published",
+    );
+    await expect(page.locator('[data-cy="share_btn"]')).toBeEnabled();
+
+    // Copying the link gives transient "Copied!" feedback.
+    await page.locator('[data-cy="share_btn"]').click();
+    await expect(page.locator('[data-cy="share_btn"]')).toContainText("Copied!");
+  });
+});


### PR DESCRIPTION
Add a Responses section to the form editor with Summary, Question and Individual views, backed by a responses store and a summarizeQuestion aggregation util that builds chart-ready data per question type. Adds publish/unpublish and share-link controls to the form navbar and makes the public view route accessible without auth.

Covered by e2e tests in tests/responses.spec.ts.